### PR TITLE
docs: add Swagger/OpenAPI documentation for all API endpoints

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,6 +36,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/platform-socket.io": "^10.4.22",
     "@nestjs/schedule": "^6.1.0",
+    "@nestjs/swagger": "^11.2.5",
     "@nestjs/websockets": "^10.4.22",
     "@prisma/client": "^5.10.0",
     "axios": "^1.13.2",
@@ -49,6 +50,7 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.3",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -16,9 +17,28 @@ async function bootstrap() {
     }),
   );
 
+  const config = new DocumentBuilder()
+    .setTitle('Hospital ERP API')
+    .setDescription('Inpatient Management ERP System API Documentation')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .addTag('auth', 'Authentication endpoints')
+    .addTag('patients', 'Patient management')
+    .addTag('rooms', 'Room and bed management')
+    .addTag('admissions', 'Admission/discharge management')
+    .addTag('vitals', 'Vital signs recording')
+    .addTag('rounds', 'Rounding management')
+    .addTag('reports', 'Reporting endpoints')
+    .addTag('admin', 'Admin functions')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+
   const port = process.env.PORT ?? 3000;
   await app.listen(port);
 
   console.log(`Application is running on: http://localhost:${port}`);
+  console.log(`Swagger documentation available at: http://localhost:${port}/api/docs`);
 }
 bootstrap();

--- a/apps/backend/src/modules/admin/audit.controller.ts
+++ b/apps/backend/src/modules/admin/audit.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param, Query, UseGuards, Logger, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../common/guards';
 import { PermissionGuard } from '../auth/guards';
 import { RequirePermission } from '../auth/decorators';
@@ -16,6 +17,8 @@ import {
   SuspiciousActivityResponseDto,
 } from './dto';
 
+@ApiTags('admin')
+@ApiBearerAuth()
 @Controller('admin/audit')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 @RequirePermission('admin:audit')
@@ -28,6 +31,14 @@ export class AuditController {
    * Query login history with filtering and pagination
    * GET /admin/audit/login-history
    */
+  @ApiOperation({ summary: 'Query login history with filtering and pagination' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of login history',
+    type: PaginatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
   @Get('login-history')
   async queryLoginHistory(
     @Query() query: QueryLoginHistoryDto,
@@ -55,6 +66,14 @@ export class AuditController {
    * Query access logs with filtering and pagination
    * GET /admin/audit/access-logs
    */
+  @ApiOperation({ summary: 'Query access logs with filtering and pagination' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of access logs',
+    type: PaginatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
   @Get('access-logs')
   async queryAccessLogs(
     @Query() query: QueryAccessLogsDto,
@@ -83,6 +102,14 @@ export class AuditController {
    * Query change logs with filtering and pagination
    * GET /admin/audit/change-logs
    */
+  @ApiOperation({ summary: 'Query change logs with filtering and pagination' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of change logs',
+    type: PaginatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
   @Get('change-logs')
   async queryChangeLogs(
     @Query() query: QueryChangeLogsDto,
@@ -111,6 +138,16 @@ export class AuditController {
    * Get patient access report
    * GET /admin/audit/patients/:patientId/access-report
    */
+  @ApiOperation({ summary: 'Get patient access report for a date range' })
+  @ApiParam({ name: 'patientId', description: 'Patient ID', format: 'uuid' })
+  @ApiResponse({
+    status: 200,
+    description: 'Patient access report',
+    type: PatientAccessReportResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Get('patients/:patientId/access-report')
   async getPatientAccessReport(
     @Param('patientId', ParseUUIDPipe) patientId: string,
@@ -128,6 +165,12 @@ export class AuditController {
    * Get user activity report
    * GET /admin/audit/users/:userId/activity-report
    */
+  @ApiOperation({ summary: 'Get user activity report for a date range' })
+  @ApiParam({ name: 'userId', description: 'User ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'User activity report' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   @Get('users/:userId/activity-report')
   async getUserActivityReport(
     @Param('userId', ParseUUIDPipe) userId: string,
@@ -145,6 +188,14 @@ export class AuditController {
    * Get suspicious activity (multiple failed logins)
    * GET /admin/audit/security/suspicious-activity
    */
+  @ApiOperation({ summary: 'Get suspicious activity report (multiple failed logins)' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of suspicious activity',
+    type: [SuspiciousActivityResponseDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
   @Get('security/suspicious-activity')
   async getSuspiciousActivity(
     @Query() query: DateRangeDto,
@@ -161,6 +212,14 @@ export class AuditController {
    * Get failed login attempts
    * GET /admin/audit/security/failed-logins
    */
+  @ApiOperation({ summary: 'Get failed login attempts for a date range' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of failed login attempts',
+    type: PaginatedResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires admin:audit permission' })
   @Get('security/failed-logins')
   async getFailedLoginAttempts(
     @Query() query: DateRangeDto,

--- a/apps/backend/src/modules/admin/dto/audit-response.dto.ts
+++ b/apps/backend/src/modules/admin/dto/audit-response.dto.ts
@@ -1,18 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { LoginHistory, AccessLog, ChangeLog, AuditAction, DeviceType } from '@prisma/client';
 
 export class LoginHistoryResponseDto {
+  @ApiProperty({ description: 'Login history record ID', format: 'uuid' })
   id: string;
+
+  @ApiPropertyOptional({
+    description: 'User ID if login was successful',
+    format: 'uuid',
+    nullable: true,
+  })
   userId: string | null;
+
+  @ApiProperty({ description: 'Username used for login attempt' })
   username: string;
+
+  @ApiProperty({ description: 'IP address of the login attempt' })
   ipAddress: string;
+
+  @ApiPropertyOptional({ description: 'User agent string from the browser', nullable: true })
   userAgent: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Device type',
+    enum: ['PC', 'TABLET', 'MOBILE'],
+    nullable: true,
+  })
   deviceType: DeviceType | null;
+
+  @ApiPropertyOptional({ description: 'Browser name', nullable: true })
   browser: string | null;
+
+  @ApiPropertyOptional({ description: 'Operating system', nullable: true })
   os: string | null;
+
+  @ApiProperty({ description: 'Login timestamp' })
   loginAt: Date;
+
+  @ApiPropertyOptional({ description: 'Logout timestamp', nullable: true })
   logoutAt: Date | null;
+
+  @ApiPropertyOptional({ description: 'Session ID if login was successful', nullable: true })
   sessionId: string | null;
+
+  @ApiProperty({ description: 'Whether the login was successful' })
   success: boolean;
+
+  @ApiPropertyOptional({ description: 'Reason for login failure', nullable: true })
   failureReason: string | null;
 
   constructor(data: LoginHistory) {
@@ -33,21 +67,56 @@ export class LoginHistoryResponseDto {
 }
 
 export class AccessLogResponseDto {
+  @ApiProperty({ description: 'Access log record ID', format: 'uuid' })
   id: string;
+
+  @ApiProperty({ description: 'User ID who accessed the resource', format: 'uuid' })
   userId: string;
+
+  @ApiProperty({ description: 'Username who accessed the resource' })
   username: string;
+
+  @ApiPropertyOptional({ description: 'User role at time of access', nullable: true })
   userRole: string | null;
+
+  @ApiProperty({ description: 'IP address of the request' })
   ipAddress: string;
+
+  @ApiProperty({ description: 'Type of resource accessed' })
   resourceType: string;
+
+  @ApiProperty({ description: 'ID of the resource accessed', format: 'uuid' })
   resourceId: string;
+
+  @ApiProperty({ description: 'Action performed', enum: ['CREATE', 'READ', 'UPDATE', 'DELETE'] })
   action: AuditAction;
+
+  @ApiPropertyOptional({ description: 'Request path', nullable: true })
   requestPath: string | null;
+
+  @ApiPropertyOptional({ description: 'HTTP request method', nullable: true })
   requestMethod: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Patient ID if accessing patient data',
+    format: 'uuid',
+    nullable: true,
+  })
   patientId: string | null;
+
+  @ApiProperty({ description: 'List of fields that were accessed', type: [String] })
   accessedFields: string[];
+
+  @ApiProperty({ description: 'Whether the access was successful' })
   success: boolean;
+
+  @ApiPropertyOptional({ description: 'Error code if access failed', nullable: true })
   errorCode: string | null;
+
+  @ApiPropertyOptional({ description: 'Error message if access failed', nullable: true })
   errorMessage: string | null;
+
+  @ApiProperty({ description: 'Timestamp of the access' })
   createdAt: Date;
 
   constructor(data: AccessLog) {
@@ -71,18 +140,51 @@ export class AccessLogResponseDto {
 }
 
 export class ChangeLogResponseDto {
+  @ApiProperty({ description: 'Change log record ID', format: 'uuid' })
   id: string;
+
+  @ApiProperty({ description: 'User ID who made the change', format: 'uuid' })
   userId: string;
+
+  @ApiProperty({ description: 'Username who made the change' })
   username: string;
+
+  @ApiPropertyOptional({ description: 'IP address of the request', nullable: true })
   ipAddress: string | null;
+
+  @ApiProperty({ description: 'Database schema name' })
   tableSchema: string;
+
+  @ApiProperty({ description: 'Table name' })
   tableName: string;
+
+  @ApiProperty({ description: 'Record ID that was changed', format: 'uuid' })
   recordId: string;
+
+  @ApiProperty({ description: 'Action performed', enum: ['CREATE', 'READ', 'UPDATE', 'DELETE'] })
   action: AuditAction;
+
+  @ApiPropertyOptional({
+    description: 'Previous values before the change',
+    type: 'object',
+    additionalProperties: true,
+  })
   oldValues: unknown;
+
+  @ApiPropertyOptional({
+    description: 'New values after the change',
+    type: 'object',
+    additionalProperties: true,
+  })
   newValues: unknown;
+
+  @ApiProperty({ description: 'List of fields that were changed', type: [String] })
   changedFields: string[];
+
+  @ApiPropertyOptional({ description: 'Reason for the change', nullable: true })
   changeReason: string | null;
+
+  @ApiProperty({ description: 'Timestamp of the change' })
   createdAt: Date;
 
   constructor(data: ChangeLog) {
@@ -103,10 +205,19 @@ export class ChangeLogResponseDto {
 }
 
 export class PaginatedResponseDto<T> {
+  @ApiProperty({ description: 'Array of data items', isArray: true })
   data: T[];
+
+  @ApiProperty({ description: 'Total number of items' })
   total: number;
+
+  @ApiProperty({ description: 'Current page number' })
   page: number;
+
+  @ApiProperty({ description: 'Number of items per page' })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages' })
   totalPages: number;
 
   constructor(result: {
@@ -124,22 +235,77 @@ export class PaginatedResponseDto<T> {
   }
 }
 
+class AccessByUserDto {
+  @ApiProperty({ description: 'User ID', format: 'uuid' })
+  userId: string;
+
+  @ApiProperty({ description: 'Username' })
+  username: string;
+
+  @ApiProperty({ description: 'Number of accesses' })
+  accessCount: number;
+}
+
+class AccessByTypeDto {
+  @ApiProperty({ description: 'Action type' })
+  action: string;
+
+  @ApiProperty({ description: 'Number of accesses' })
+  count: number;
+}
+
+class AccessTimelineDto {
+  @ApiProperty({ description: 'User ID', format: 'uuid' })
+  userId: string;
+
+  @ApiProperty({ description: 'Username' })
+  username: string;
+
+  @ApiProperty({ description: 'Action performed' })
+  action: string;
+
+  @ApiProperty({ description: 'Fields that were accessed', type: [String] })
+  accessedFields: string[];
+
+  @ApiProperty({ description: 'Timestamp of the access' })
+  timestamp: Date;
+}
+
+class DateRangeResponseDto {
+  @ApiProperty({ description: 'Start date of the range' })
+  startDate: Date;
+
+  @ApiProperty({ description: 'End date of the range' })
+  endDate: Date;
+}
+
 export class PatientAccessReportResponseDto {
+  @ApiProperty({ description: 'Patient ID', format: 'uuid' })
   patientId: string;
+
+  @ApiProperty({ description: 'Date range of the report', type: DateRangeResponseDto })
   dateRange: {
     startDate: Date;
     endDate: Date;
   };
+
+  @ApiProperty({ description: 'Total number of accesses' })
   totalAccess: number;
+
+  @ApiProperty({ description: 'Access breakdown by user', type: [AccessByUserDto] })
   accessByUser: Array<{
     userId: string;
     username: string;
     accessCount: number;
   }>;
+
+  @ApiProperty({ description: 'Access breakdown by action type', type: [AccessByTypeDto] })
   accessByType: Array<{
     action: string;
     count: number;
   }>;
+
+  @ApiProperty({ description: 'Timeline of accesses', type: [AccessTimelineDto] })
   timeline: Array<{
     userId: string;
     username: string;
@@ -150,7 +316,12 @@ export class PatientAccessReportResponseDto {
 }
 
 export class SuspiciousActivityResponseDto {
+  @ApiProperty({ description: 'IP address with suspicious activity' })
   ipAddress: string;
+
+  @ApiProperty({ description: 'Number of failed login attempts' })
   failedAttempts: number;
+
+  @ApiProperty({ description: 'Usernames attempted from this IP', type: [String] })
   usernames: string[];
 }

--- a/apps/backend/src/modules/admin/dto/query-audit.dto.ts
+++ b/apps/backend/src/modules/admin/dto/query-audit.dto.ts
@@ -10,40 +10,54 @@ import {
   Max,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AuditAction } from '@prisma/client';
 
 export class QueryLoginHistoryDto {
+  @ApiPropertyOptional({ description: 'Filter by user ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   userId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by username' })
   @IsOptional()
   @IsString()
   username?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by IP address' })
   @IsOptional()
   @IsString()
   ipAddress?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by login success status' })
   @IsOptional()
   @Transform(({ value }) => value === 'true')
   @IsBoolean()
   success?: boolean;
 
+  @ApiPropertyOptional({ description: 'Start date for date range filter', format: 'date-time' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date for date range filter', format: 'date-time' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -53,40 +67,57 @@ export class QueryLoginHistoryDto {
 }
 
 export class QueryAccessLogsDto {
+  @ApiPropertyOptional({ description: 'Filter by user ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   userId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by patient ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   patientId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by resource type' })
   @IsOptional()
   @IsString()
   resourceType?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by resource ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   resourceId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by audit action',
+    enum: ['CREATE', 'READ', 'UPDATE', 'DELETE'],
+  })
   @IsOptional()
   @IsEnum(AuditAction)
   action?: AuditAction;
 
+  @ApiPropertyOptional({ description: 'Start date for date range filter', format: 'date-time' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date for date range filter', format: 'date-time' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -96,40 +127,57 @@ export class QueryAccessLogsDto {
 }
 
 export class QueryChangeLogsDto {
+  @ApiPropertyOptional({ description: 'Filter by user ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   userId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by database schema name' })
   @IsOptional()
   @IsString()
   tableSchema?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by table name' })
   @IsOptional()
   @IsString()
   tableName?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by record ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   recordId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by audit action',
+    enum: ['CREATE', 'READ', 'UPDATE', 'DELETE'],
+  })
   @IsOptional()
   @IsEnum(AuditAction)
   action?: AuditAction;
 
+  @ApiPropertyOptional({ description: 'Start date for date range filter', format: 'date-time' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date for date range filter', format: 'date-time' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -139,9 +187,11 @@ export class QueryChangeLogsDto {
 }
 
 export class DateRangeDto {
+  @ApiProperty({ description: 'Start date of the range', format: 'date-time' })
   @IsDateString()
   startDate: string;
 
+  @ApiProperty({ description: 'End date of the range', format: 'date-time' })
   @IsDateString()
   endDate: string;
 }

--- a/apps/backend/src/modules/admin/dto/user-admin.dto.ts
+++ b/apps/backend/src/modules/admin/dto/user-admin.dto.ts
@@ -14,6 +14,7 @@ import {
   Matches,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * DTO for creating a new user
@@ -21,11 +22,17 @@ import { Type } from 'class-transformer';
  * Requirements: REQ-FR-060
  */
 export class CreateUserDto {
+  @ApiProperty({ description: 'Employee ID', maxLength: 20 })
   @IsNotEmpty()
   @IsString()
   @MaxLength(20)
   employeeId: string;
 
+  @ApiProperty({
+    description: 'Username (letters, numbers, underscores only)',
+    minLength: 4,
+    maxLength: 50,
+  })
   @IsNotEmpty()
   @IsString()
   @MinLength(4)
@@ -35,31 +42,37 @@ export class CreateUserDto {
   })
   username: string;
 
+  @ApiProperty({ description: 'Full name of the user', maxLength: 100 })
   @IsNotEmpty()
   @IsString()
   @MaxLength(100)
   name: string;
 
+  @ApiPropertyOptional({ description: 'Email address', format: 'email', maxLength: 255 })
   @IsOptional()
   @IsEmail()
   @MaxLength(255)
   email?: string;
 
+  @ApiPropertyOptional({ description: 'Phone number', maxLength: 20 })
   @IsOptional()
   @IsString()
   @MaxLength(20)
   phone?: string;
 
+  @ApiPropertyOptional({ description: 'Department name', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   department?: string;
 
+  @ApiPropertyOptional({ description: 'Job position/title', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   position?: string;
 
+  @ApiProperty({ description: 'Array of role IDs to assign', type: [String], format: 'uuid' })
   @IsArray()
   @IsUUID('4', { each: true })
   roleIds: string[];
@@ -70,31 +83,37 @@ export class CreateUserDto {
  * Reference: Issue #28 (User and Role Management Service)
  */
 export class UpdateUserDto {
+  @ApiPropertyOptional({ description: 'Full name of the user', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Email address', format: 'email', maxLength: 255 })
   @IsOptional()
   @IsEmail()
   @MaxLength(255)
   email?: string;
 
+  @ApiPropertyOptional({ description: 'Phone number', maxLength: 20 })
   @IsOptional()
   @IsString()
   @MaxLength(20)
   phone?: string;
 
+  @ApiPropertyOptional({ description: 'Department name', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   department?: string;
 
+  @ApiPropertyOptional({ description: 'Job position/title', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   position?: string;
 
+  @ApiPropertyOptional({ description: 'Whether the user account is active' })
   @IsOptional()
   @IsBoolean()
   isActive?: boolean;
@@ -106,6 +125,7 @@ export class UpdateUserDto {
  * Requirements: REQ-FR-061
  */
 export class AssignRoleDto {
+  @ApiProperty({ description: 'Role ID to assign', format: 'uuid' })
   @IsNotEmpty()
   @IsUUID('4')
   roleId: string;
@@ -115,29 +135,40 @@ export class AssignRoleDto {
  * DTO for listing users with pagination and filters
  */
 export class ListUsersDto {
+  @ApiPropertyOptional({ description: 'Search term for username, name, or employee ID' })
   @IsOptional()
   @IsString()
   search?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by department' })
   @IsOptional()
   @IsString()
   department?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by active status' })
   @IsOptional()
   @IsBoolean()
   @Type(() => Boolean)
   isActive?: boolean;
 
+  @ApiPropertyOptional({ description: 'Filter by role ID', format: 'uuid' })
   @IsOptional()
   @IsUUID('4')
   roleId?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Number of items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -145,10 +176,12 @@ export class ListUsersDto {
   @Max(100)
   limit?: number = 20;
 
+  @ApiPropertyOptional({ description: 'Field to sort by', default: 'createdAt' })
   @IsOptional()
   @IsString()
   sortBy?: string = 'createdAt';
 
+  @ApiPropertyOptional({ description: 'Sort order', enum: ['asc', 'desc'], default: 'desc' })
   @IsOptional()
   @IsString()
   @Matches(/^(asc|desc)$/i)
@@ -159,18 +192,43 @@ export class ListUsersDto {
  * Response DTO for user data
  */
 export class UserResponseDto {
+  @ApiProperty({ description: 'User ID', format: 'uuid' })
   id: string;
+
+  @ApiProperty({ description: 'Employee ID' })
   employeeId: string;
+
+  @ApiProperty({ description: 'Username' })
   username: string;
+
+  @ApiProperty({ description: 'Full name' })
   name: string;
+
+  @ApiPropertyOptional({ description: 'Email address' })
   email?: string;
+
+  @ApiPropertyOptional({ description: 'Phone number' })
   phone?: string;
+
+  @ApiPropertyOptional({ description: 'Department' })
   department?: string;
+
+  @ApiPropertyOptional({ description: 'Position/title' })
   position?: string;
+
+  @ApiProperty({ description: 'Whether the user account is active' })
   isActive: boolean;
+
+  @ApiPropertyOptional({ description: 'Last login timestamp' })
   lastLoginAt?: Date;
+
+  @ApiProperty({ description: 'Account creation timestamp' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt: Date;
+
+  @ApiProperty({ description: 'Assigned roles', type: () => [RoleBasicDto] })
   roles: RoleBasicDto[];
 
   constructor(partial: Partial<UserResponseDto>) {
@@ -182,6 +240,7 @@ export class UserResponseDto {
  * Response DTO for user creation with temporary password
  */
 export class CreateUserResponseDto extends UserResponseDto {
+  @ApiProperty({ description: 'Temporary password for the new user' })
   temporaryPassword: string;
 
   constructor(partial: Partial<CreateUserResponseDto>) {
@@ -194,7 +253,10 @@ export class CreateUserResponseDto extends UserResponseDto {
  * Response DTO for password reset
  */
 export class ResetPasswordResponseDto {
+  @ApiProperty({ description: 'New temporary password' })
   temporaryPassword: string;
+
+  @ApiProperty({ description: 'Response message' })
   message: string;
 
   constructor(temporaryPassword: string) {
@@ -207,8 +269,13 @@ export class ResetPasswordResponseDto {
  * Basic role information DTO
  */
 export class RoleBasicDto {
+  @ApiProperty({ description: 'Role ID', format: 'uuid' })
   id: string;
+
+  @ApiProperty({ description: 'Role code' })
   code: string;
+
+  @ApiProperty({ description: 'Role name' })
   name: string;
 
   constructor(partial: Partial<RoleBasicDto>) {
@@ -220,10 +287,19 @@ export class RoleBasicDto {
  * Full role response DTO with permissions
  */
 export class RoleResponseDto extends RoleBasicDto {
+  @ApiPropertyOptional({ description: 'Role description' })
   description?: string;
+
+  @ApiProperty({ description: 'Role hierarchy level' })
   level: number;
+
+  @ApiProperty({ description: 'Whether the role is active' })
   isActive: boolean;
+
+  @ApiProperty({ description: 'Role creation timestamp' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt: Date;
 
   constructor(partial: Partial<RoleResponseDto>) {
@@ -236,6 +312,7 @@ export class RoleResponseDto extends RoleBasicDto {
  * Role with permissions response DTO
  */
 export class RoleWithPermissionsDto extends RoleResponseDto {
+  @ApiProperty({ description: 'Permissions assigned to this role', type: () => [PermissionDto] })
   permissions: PermissionDto[];
 
   constructor(partial: Partial<RoleWithPermissionsDto>) {
@@ -248,10 +325,19 @@ export class RoleWithPermissionsDto extends RoleResponseDto {
  * Permission DTO
  */
 export class PermissionDto {
+  @ApiProperty({ description: 'Permission ID', format: 'uuid' })
   id: string;
+
+  @ApiProperty({ description: 'Permission code' })
   code: string;
+
+  @ApiProperty({ description: 'Resource that the permission applies to' })
   resource: string;
+
+  @ApiProperty({ description: 'Action allowed by this permission' })
   action: string;
+
+  @ApiPropertyOptional({ description: 'Permission description' })
   description?: string;
 
   constructor(partial: Partial<PermissionDto>) {
@@ -260,10 +346,36 @@ export class PermissionDto {
 }
 
 /**
+ * Pagination metadata DTO
+ */
+export class PaginationMetaDto {
+  @ApiProperty({ description: 'Total number of items' })
+  total: number;
+
+  @ApiProperty({ description: 'Current page number' })
+  page: number;
+
+  @ApiProperty({ description: 'Number of items per page' })
+  limit: number;
+
+  @ApiProperty({ description: 'Total number of pages' })
+  totalPages: number;
+
+  @ApiProperty({ description: 'Whether there is a next page' })
+  hasNextPage: boolean;
+
+  @ApiProperty({ description: 'Whether there is a previous page' })
+  hasPrevPage: boolean;
+}
+
+/**
  * Paginated result wrapper
  */
 export class PaginatedResultDto<T> {
+  @ApiProperty({ description: 'Array of data items', isArray: true })
   data: T[];
+
+  @ApiProperty({ description: 'Pagination metadata', type: PaginationMetaDto })
   meta: {
     total: number;
     page: number;
@@ -291,6 +403,7 @@ export class PaginatedResultDto<T> {
  * Message response DTO for simple operations
  */
 export class MessageResponseDto {
+  @ApiProperty({ description: 'Response message' })
   message: string;
 
   constructor(message: string) {

--- a/apps/backend/src/modules/admin/role.controller.ts
+++ b/apps/backend/src/modules/admin/role.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Param, UseGuards, Logger, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../common/guards';
 import { PermissionGuard } from '../auth/guards';
 import { RequireRole } from '../auth/decorators';
@@ -10,6 +11,8 @@ import { RoleResponseDto, RoleWithPermissionsDto } from './dto';
  * Reference: Issue #28 (User and Role Management Service)
  * Requirements: REQ-FR-061
  */
+@ApiTags('admin')
+@ApiBearerAuth()
 @Controller('admin/roles')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 @RequireRole('ADMIN')
@@ -22,6 +25,10 @@ export class RoleController {
    * List all roles
    * GET /admin/roles
    */
+  @ApiOperation({ summary: 'List all roles' })
+  @ApiResponse({ status: 200, description: 'List of all roles', type: [RoleResponseDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
   @Get()
   async list(): Promise<RoleResponseDto[]> {
     this.logger.log('Listing roles');
@@ -32,6 +39,12 @@ export class RoleController {
    * Get role by ID
    * GET /admin/roles/:id
    */
+  @ApiOperation({ summary: 'Get role by ID' })
+  @ApiParam({ name: 'id', description: 'Role ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Role details', type: RoleResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Role not found' })
   @Get(':id')
   async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<RoleResponseDto> {
     this.logger.log(`Getting role ${id}`);
@@ -42,6 +55,12 @@ export class RoleController {
    * Get role with permissions
    * GET /admin/roles/:id/permissions
    */
+  @ApiOperation({ summary: 'Get role with permissions' })
+  @ApiParam({ name: 'id', description: 'Role ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Role with permissions', type: RoleWithPermissionsDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Role not found' })
   @Get(':id/permissions')
   async getWithPermissions(
     @Param('id', ParseUUIDPipe) id: string,

--- a/apps/backend/src/modules/admin/user-admin.controller.ts
+++ b/apps/backend/src/modules/admin/user-admin.controller.ts
@@ -13,6 +13,7 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../common/guards';
 import { CurrentUser } from '../../common/decorators';
 import { PermissionGuard } from '../auth/guards';
@@ -36,6 +37,8 @@ import {
  * Reference: Issue #28 (User and Role Management Service)
  * Requirements: REQ-FR-060~061
  */
+@ApiTags('admin')
+@ApiBearerAuth()
 @Controller('admin/users')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 @RequireRole('ADMIN')
@@ -48,6 +51,10 @@ export class UserAdminController {
    * List all users with pagination and filters
    * GET /admin/users
    */
+  @ApiOperation({ summary: 'List all users with pagination and filters' })
+  @ApiResponse({ status: 200, description: 'Paginated list of users', type: PaginatedResultDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
   @Get()
   async list(@Query() query: ListUsersDto): Promise<PaginatedResultDto<UserResponseDto>> {
     this.logger.log('Listing users');
@@ -58,6 +65,12 @@ export class UserAdminController {
    * Get user by ID
    * GET /admin/users/:id
    */
+  @ApiOperation({ summary: 'Get user by ID' })
+  @ApiParam({ name: 'id', description: 'User ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'User details', type: UserResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   @Get(':id')
   async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<UserResponseDto> {
     this.logger.log(`Getting user ${id}`);
@@ -68,6 +81,16 @@ export class UserAdminController {
    * Create a new user
    * POST /admin/users
    */
+  @ApiOperation({ summary: 'Create a new user' })
+  @ApiResponse({
+    status: 201,
+    description: 'User created successfully',
+    type: CreateUserResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 409, description: 'Username or employee ID already exists' })
   @Post()
   async create(
     @Body() dto: CreateUserDto,
@@ -81,6 +104,13 @@ export class UserAdminController {
    * Update user
    * PATCH /admin/users/:id
    */
+  @ApiOperation({ summary: 'Update user information' })
+  @ApiParam({ name: 'id', description: 'User ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'User updated successfully', type: UserResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   @Patch(':id')
   async update(
     @Param('id', ParseUUIDPipe) id: string,
@@ -95,6 +125,12 @@ export class UserAdminController {
    * Deactivate user
    * DELETE /admin/users/:id
    */
+  @ApiOperation({ summary: 'Deactivate user account' })
+  @ApiParam({ name: 'id', description: 'User ID', format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'User deactivated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async deactivate(
@@ -109,6 +145,16 @@ export class UserAdminController {
    * Reset user password
    * POST /admin/users/:id/reset-password
    */
+  @ApiOperation({ summary: 'Reset user password' })
+  @ApiParam({ name: 'id', description: 'User ID', format: 'uuid' })
+  @ApiResponse({
+    status: 200,
+    description: 'Password reset successfully',
+    type: ResetPasswordResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   @Post(':id/reset-password')
   async resetPassword(
     @Param('id', ParseUUIDPipe) id: string,
@@ -122,6 +168,14 @@ export class UserAdminController {
    * Assign role to user
    * POST /admin/users/:id/roles
    */
+  @ApiOperation({ summary: 'Assign role to user' })
+  @ApiParam({ name: 'id', description: 'User ID', format: 'uuid' })
+  @ApiResponse({ status: 201, description: 'Role assigned successfully', type: MessageResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid role ID' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'User or role not found' })
+  @ApiResponse({ status: 409, description: 'Role already assigned to user' })
   @Post(':id/roles')
   @HttpCode(HttpStatus.CREATED)
   async assignRole(
@@ -138,6 +192,13 @@ export class UserAdminController {
    * Remove role from user
    * DELETE /admin/users/:id/roles/:roleId
    */
+  @ApiOperation({ summary: 'Remove role from user' })
+  @ApiParam({ name: 'id', description: 'User ID', format: 'uuid' })
+  @ApiParam({ name: 'roleId', description: 'Role ID to remove', format: 'uuid' })
+  @ApiResponse({ status: 204, description: 'Role removed successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'User or role assignment not found' })
   @Delete(':id/roles/:roleId')
   @HttpCode(HttpStatus.NO_CONTENT)
   async removeRole(

--- a/apps/backend/src/modules/admission/admission.controller.ts
+++ b/apps/backend/src/modules/admission/admission.controller.ts
@@ -1,4 +1,12 @@
 import { Controller, Get, Post, Body, Param, Query, Headers } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { AdmissionService } from './admission.service';
 import { ParseUUIDPipe } from '../../common';
 import { AdmissionStatus } from '@prisma/client';
@@ -13,10 +21,21 @@ import {
   DischargeResponseDto,
 } from './dto';
 
+@ApiTags('admissions')
+@ApiBearerAuth()
 @Controller('admissions')
 export class AdmissionController {
   constructor(private readonly admissionService: AdmissionService) {}
 
+  @ApiOperation({ summary: 'Create a new admission' })
+  @ApiResponse({
+    status: 201,
+    description: 'Admission created successfully',
+    type: AdmissionResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 409, description: 'Bed is already occupied or patient already admitted' })
   @Post()
   async create(
     @Body() dto: CreateAdmissionDto,
@@ -26,11 +45,23 @@ export class AdmissionController {
     return this.admissionService.admitPatient(dto, effectiveUserId);
   }
 
+  @ApiOperation({ summary: 'Get all admissions with pagination and filters' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of admissions',
+    type: PaginatedAdmissionsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get()
   async findAll(@Query() dto: FindAdmissionsDto): Promise<PaginatedAdmissionsResponseDto> {
     return this.admissionService.findAll(dto);
   }
 
+  @ApiOperation({ summary: 'Find admission by admission number' })
+  @ApiParam({ name: 'admissionNumber', description: 'Admission number', example: 'ADM2025000001' })
+  @ApiResponse({ status: 200, description: 'Admission found', type: AdmissionResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('by-number/:admissionNumber')
   async findByAdmissionNumber(
     @Param('admissionNumber') admissionNumber: string,
@@ -38,6 +69,14 @@ export class AdmissionController {
     return this.admissionService.findByAdmissionNumber(admissionNumber);
   }
 
+  @ApiOperation({ summary: 'Find active admission for a patient' })
+  @ApiParam({ name: 'patientId', description: 'Patient ID', format: 'uuid' })
+  @ApiResponse({
+    status: 200,
+    description: 'Active admission found or null',
+    type: AdmissionResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('patient/:patientId/active')
   async findActiveByPatient(
     @Param('patientId', ParseUUIDPipe) patientId: string,
@@ -45,6 +84,20 @@ export class AdmissionController {
     return this.admissionService.findActiveByPatient(patientId);
   }
 
+  @ApiOperation({ summary: 'Find all admissions by floor' })
+  @ApiParam({ name: 'floorId', description: 'Floor ID', format: 'uuid' })
+  @ApiQuery({
+    name: 'status',
+    description: 'Filter by admission status',
+    required: false,
+    enum: ['ADMITTED', 'DISCHARGED', 'TRANSFERRED'],
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of admissions on the floor',
+    type: [AdmissionResponseDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get('floor/:floorId')
   async findByFloor(
     @Param('floorId', ParseUUIDPipe) floorId: string,
@@ -53,11 +106,27 @@ export class AdmissionController {
     return this.admissionService.findByFloor(floorId, status);
   }
 
+  @ApiOperation({ summary: 'Find admission by ID' })
+  @ApiParam({ name: 'id', description: 'Admission ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Admission found', type: AdmissionResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get(':id')
   async findById(@Param('id', ParseUUIDPipe) id: string): Promise<AdmissionResponseDto> {
     return this.admissionService.findById(id);
   }
 
+  @ApiOperation({ summary: 'Transfer patient to a different bed' })
+  @ApiParam({ name: 'id', description: 'Admission ID', format: 'uuid' })
+  @ApiResponse({
+    status: 201,
+    description: 'Patient transferred successfully',
+    type: TransferResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
+  @ApiResponse({ status: 409, description: 'Target bed is occupied' })
   @Post(':id/transfer')
   async transfer(
     @Param('id', ParseUUIDPipe) id: string,
@@ -68,6 +137,17 @@ export class AdmissionController {
     return this.admissionService.transferPatient(id, dto, effectiveUserId);
   }
 
+  @ApiOperation({ summary: 'Discharge patient' })
+  @ApiParam({ name: 'id', description: 'Admission ID', format: 'uuid' })
+  @ApiResponse({
+    status: 201,
+    description: 'Patient discharged successfully',
+    type: DischargeResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
+  @ApiResponse({ status: 409, description: 'Patient already discharged' })
   @Post(':id/discharge')
   async discharge(
     @Param('id', ParseUUIDPipe) id: string,
@@ -78,6 +158,11 @@ export class AdmissionController {
     return this.admissionService.dischargePatient(id, dto, effectiveUserId);
   }
 
+  @ApiOperation({ summary: 'Get transfer history for an admission' })
+  @ApiParam({ name: 'id', description: 'Admission ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'List of transfers', type: [TransferResponseDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get(':id/transfers')
   async getTransferHistory(@Param('id', ParseUUIDPipe) id: string): Promise<TransferResponseDto[]> {
     return this.admissionService.getTransferHistory(id);

--- a/apps/backend/src/modules/admission/dto/admission-response.dto.ts
+++ b/apps/backend/src/modules/admission/dto/admission-response.dto.ts
@@ -1,58 +1,158 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AdmissionType, AdmissionStatus, DischargeType } from '@prisma/client';
 
 export class TransferResponseDto {
+  @ApiProperty({ description: 'Transfer ID', example: '550e8400-e29b-41d4-a716-446655440020' })
   id: string;
+
+  @ApiProperty({
+    description: 'Associated admission ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   admissionId: string;
+
+  @ApiProperty({ description: 'Source bed ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   fromBedId: string;
+
+  @ApiProperty({ description: 'Target bed ID', example: '550e8400-e29b-41d4-a716-446655440010' })
   toBedId: string;
+
+  @ApiProperty({ description: 'Transfer date' })
   transferDate: Date;
+
+  @ApiProperty({ description: 'Transfer time', example: '10:00' })
   transferTime: string;
+
+  @ApiProperty({ description: 'Reason for transfer', example: 'Patient requires ICU monitoring' })
   reason: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'User ID who performed the transfer' })
   transferredBy: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt: Date;
 }
 
 export class DischargeResponseDto {
+  @ApiProperty({ description: 'Discharge ID', example: '550e8400-e29b-41d4-a716-446655440030' })
   id: string;
+
+  @ApiProperty({
+    description: 'Associated admission ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   admissionId: string;
+
+  @ApiProperty({ description: 'Discharge date' })
   dischargeDate: Date;
+
+  @ApiProperty({ description: 'Discharge time', example: '11:00' })
   dischargeTime: string;
+
+  @ApiProperty({
+    description: 'Type of discharge',
+    enum: ['NORMAL', 'TRANSFER', 'AMA', 'DECEASED'],
+  })
   dischargeType: DischargeType;
+
+  @ApiPropertyOptional({ description: 'Discharge diagnosis', nullable: true })
   dischargeDiagnosis: string | null;
+
+  @ApiPropertyOptional({ description: 'Discharge summary', nullable: true })
   dischargeSummary: string | null;
+
+  @ApiPropertyOptional({ description: 'Follow-up instructions', nullable: true })
   followUpInstructions: string | null;
+
+  @ApiPropertyOptional({ description: 'Follow-up appointment date', nullable: true })
   followUpDate: Date | null;
+
+  @ApiProperty({ description: 'User ID who performed the discharge' })
   dischargedBy: string;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt: Date;
 }
 
 export class AdmissionResponseDto {
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Patient ID', example: '550e8400-e29b-41d4-a716-446655440100' })
   patientId: string;
+
+  @ApiProperty({ description: 'Assigned bed ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   bedId: string;
+
+  @ApiProperty({ description: 'Admission number', example: 'ADM2025000001' })
   admissionNumber: string;
+
+  @ApiProperty({ description: 'Admission date' })
   admissionDate: Date;
+
+  @ApiProperty({ description: 'Admission time', example: '14:30' })
   admissionTime: string;
+
+  @ApiProperty({ description: 'Type of admission', enum: ['EMERGENCY', 'ELECTIVE', 'TRANSFER'] })
   admissionType: AdmissionType;
+
+  @ApiPropertyOptional({ description: 'Primary diagnosis', nullable: true })
   diagnosis: string | null;
+
+  @ApiPropertyOptional({ description: 'Chief complaint', nullable: true })
   chiefComplaint: string | null;
+
+  @ApiProperty({ description: 'Attending doctor ID' })
   attendingDoctorId: string;
+
+  @ApiPropertyOptional({ description: 'Primary nurse ID', nullable: true })
   primaryNurseId: string | null;
+
+  @ApiProperty({ description: 'Admission status', enum: ['ADMITTED', 'DISCHARGED', 'TRANSFERRED'] })
   status: AdmissionStatus;
+
+  @ApiPropertyOptional({ description: 'Expected discharge date', nullable: true })
   expectedDischargeDate: Date | null;
+
+  @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt: Date;
+
+  @ApiProperty({ description: 'User ID who created the admission' })
   createdBy: string;
+
+  @ApiPropertyOptional({ description: 'Transfer history', type: [TransferResponseDto] })
   transfers?: TransferResponseDto[];
+
+  @ApiPropertyOptional({
+    description: 'Discharge information',
+    type: DischargeResponseDto,
+    nullable: true,
+  })
   discharge?: DischargeResponseDto | null;
 }
 
 export class PaginatedAdmissionsResponseDto {
+  @ApiProperty({ description: 'Admission list', type: [AdmissionResponseDto] })
   data: AdmissionResponseDto[];
+
+  @ApiProperty({ description: 'Total count', example: 100 })
   total: number;
+
+  @ApiProperty({ description: 'Current page', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total pages', example: 5 })
   totalPages: number;
 }

--- a/apps/backend/src/modules/admission/dto/create-admission.dto.ts
+++ b/apps/backend/src/modules/admission/dto/create-admission.dto.ts
@@ -8,21 +8,34 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AdmissionType } from '@prisma/client';
 
 export class CreateAdmissionDto {
+  @ApiProperty({
+    description: 'Patient ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    format: 'uuid',
+  })
   @IsNotEmpty()
   @IsUUID()
   patientId: string;
 
+  @ApiProperty({
+    description: 'Bed ID to assign',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+    format: 'uuid',
+  })
   @IsNotEmpty()
   @IsUUID()
   bedId: string;
 
+  @ApiProperty({ description: 'Admission date', example: '2025-01-15', format: 'date' })
   @IsNotEmpty()
   @IsDateString()
   admissionDate: string;
 
+  @ApiProperty({ description: 'Admission time in HH:mm format', example: '14:30' })
   @IsNotEmpty()
   @IsString()
   @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
@@ -30,30 +43,57 @@ export class CreateAdmissionDto {
   })
   admissionTime: string;
 
+  @ApiProperty({
+    description: 'Type of admission',
+    enum: ['EMERGENCY', 'ELECTIVE', 'TRANSFER'],
+    example: 'ELECTIVE',
+  })
   @IsNotEmpty()
   @IsEnum(AdmissionType)
   admissionType: AdmissionType;
 
+  @ApiPropertyOptional({ description: 'Primary diagnosis', example: 'Acute appendicitis' })
   @IsOptional()
   @IsString()
   diagnosis?: string;
 
+  @ApiPropertyOptional({ description: 'Chief complaint', example: 'Severe abdominal pain' })
   @IsOptional()
   @IsString()
   chiefComplaint?: string;
 
+  @ApiProperty({
+    description: 'Attending doctor ID',
+    example: '550e8400-e29b-41d4-a716-446655440002',
+    format: 'uuid',
+  })
   @IsNotEmpty()
   @IsUUID()
   attendingDoctorId: string;
 
+  @ApiPropertyOptional({
+    description: 'Primary nurse ID',
+    example: '550e8400-e29b-41d4-a716-446655440003',
+    format: 'uuid',
+  })
   @IsOptional()
   @IsUUID()
   primaryNurseId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Expected discharge date',
+    example: '2025-01-20',
+    format: 'date',
+  })
   @IsOptional()
   @IsDateString()
   expectedDischargeDate?: string;
 
+  @ApiPropertyOptional({
+    description: 'Additional notes',
+    example: 'Patient requires special diet',
+    maxLength: 1000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(1000)

--- a/apps/backend/src/modules/admission/dto/discharge.dto.ts
+++ b/apps/backend/src/modules/admission/dto/discharge.dto.ts
@@ -7,13 +7,16 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DischargeType } from '@prisma/client';
 
 export class DischargeDto {
+  @ApiProperty({ description: 'Discharge date', example: '2025-01-20', format: 'date' })
   @IsNotEmpty()
   @IsDateString()
   dischargeDate: string;
 
+  @ApiProperty({ description: 'Discharge time in HH:mm format', example: '11:00' })
   @IsNotEmpty()
   @IsString()
   @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
@@ -21,23 +24,43 @@ export class DischargeDto {
   })
   dischargeTime: string;
 
+  @ApiProperty({
+    description: 'Type of discharge',
+    enum: ['NORMAL', 'TRANSFER', 'AMA', 'DECEASED'],
+    example: 'NORMAL',
+  })
   @IsNotEmpty()
   @IsEnum(DischargeType)
   dischargeType: DischargeType;
 
+  @ApiPropertyOptional({ description: 'Discharge diagnosis', example: 'Appendicitis, resolved' })
   @IsOptional()
   @IsString()
   dischargeDiagnosis?: string;
 
+  @ApiPropertyOptional({
+    description: 'Discharge summary',
+    example: 'Patient recovered well after appendectomy',
+  })
   @IsOptional()
   @IsString()
   dischargeSummary?: string;
 
+  @ApiPropertyOptional({
+    description: 'Follow-up instructions',
+    example: 'Rest for 2 weeks, avoid heavy lifting',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   followUpInstructions?: string;
 
+  @ApiPropertyOptional({
+    description: 'Follow-up appointment date',
+    example: '2025-02-01',
+    format: 'date',
+  })
   @IsOptional()
   @IsDateString()
   followUpDate?: string;

--- a/apps/backend/src/modules/admission/dto/find-admissions.dto.ts
+++ b/apps/backend/src/modules/admission/dto/find-admissions.dto.ts
@@ -9,47 +9,78 @@ import {
   IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { AdmissionStatus } from '@prisma/client';
 
 export class FindAdmissionsDto {
+  @ApiPropertyOptional({ description: 'Filter by patient ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   patientId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by bed ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   bedId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by floor ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   floorId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by attending doctor ID', format: 'uuid' })
   @IsOptional()
   @IsUUID()
   attendingDoctorId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by admission status',
+    enum: ['ADMITTED', 'DISCHARGED', 'TRANSFERRED'],
+  })
   @IsOptional()
   @IsEnum(AdmissionStatus)
   status?: AdmissionStatus;
 
+  @ApiPropertyOptional({
+    description: 'Filter admissions from this date',
+    example: '2025-01-01',
+    format: 'date',
+  })
   @IsOptional()
   @IsDateString()
   admissionDateFrom?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter admissions until this date',
+    example: '2025-12-31',
+    format: 'date',
+  })
   @IsOptional()
   @IsDateString()
   admissionDateTo?: string;
 
+  @ApiPropertyOptional({
+    description: 'Search by patient name or admission number',
+    example: 'John',
+  })
   @IsOptional()
   @IsString()
   search?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, minimum: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    minimum: 1,
+    maximum: 100,
+    default: 20,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/apps/backend/src/modules/admission/dto/transfer.dto.ts
+++ b/apps/backend/src/modules/admission/dto/transfer.dto.ts
@@ -7,16 +7,24 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class TransferDto {
+  @ApiProperty({
+    description: 'Target bed ID',
+    example: '550e8400-e29b-41d4-a716-446655440010',
+    format: 'uuid',
+  })
   @IsNotEmpty()
   @IsUUID()
   toBedId: string;
 
+  @ApiProperty({ description: 'Transfer date', example: '2025-01-16', format: 'date' })
   @IsNotEmpty()
   @IsDateString()
   transferDate: string;
 
+  @ApiProperty({ description: 'Transfer time in HH:mm format', example: '10:00' })
   @IsNotEmpty()
   @IsString()
   @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
@@ -24,11 +32,21 @@ export class TransferDto {
   })
   transferTime: string;
 
+  @ApiProperty({
+    description: 'Reason for transfer',
+    example: 'Patient requires ICU monitoring',
+    maxLength: 255,
+  })
   @IsNotEmpty()
   @IsString()
   @MaxLength(255)
   reason: string;
 
+  @ApiPropertyOptional({
+    description: 'Additional notes',
+    example: 'Notify family of room change',
+    maxLength: 1000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(1000)

--- a/apps/backend/src/modules/auth/dto/auth.dto.ts
+++ b/apps/backend/src/modules/auth/dto/auth.dto.ts
@@ -7,31 +7,27 @@ import {
   Matches,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DeviceInfoDto } from './session.dto';
 
-/**
- * Password validation regex pattern
- * - At least 8 characters
- * - At least 1 uppercase letter
- * - At least 1 lowercase letter
- * - At least 1 number
- * - At least 1 special character
- */
 const PASSWORD_PATTERN =
   /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/;
 const PASSWORD_MESSAGE =
   'Password must contain at least 8 characters, including uppercase, lowercase, number, and special character';
 
 export class LoginDto {
+  @ApiProperty({ description: 'Username for login', example: 'admin' })
   @IsString()
   @IsNotEmpty()
   username: string;
 
+  @ApiProperty({ description: 'User password', example: 'Password123!' })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
   password: string;
 
+  @ApiPropertyOptional({ description: 'Device information', type: DeviceInfoDto })
   @ValidateNested()
   @Type(() => DeviceInfoDto)
   @IsOptional()
@@ -39,15 +35,29 @@ export class LoginDto {
 }
 
 export class RefreshTokenDto {
+  @ApiProperty({ description: 'Refresh token', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
   @IsString()
   @IsNotEmpty()
   refreshToken: string;
 }
 
 export class TokenResponseDto {
+  @ApiProperty({
+    description: 'JWT access token',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   accessToken: string;
+
+  @ApiProperty({
+    description: 'JWT refresh token',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   refreshToken: string;
+
+  @ApiProperty({ description: 'Token expiration time in seconds', example: 3600 })
   expiresIn: number;
+
+  @ApiProperty({ description: 'Token type', example: 'Bearer' })
   tokenType: string;
 
   constructor(partial: Partial<TokenResponseDto>) {
@@ -55,23 +65,33 @@ export class TokenResponseDto {
   }
 }
 
-export class LoginResponseDto {
-  user: UserInfoDto;
-  tokens: TokenResponseDto;
-
-  constructor(partial: Partial<LoginResponseDto>) {
-    Object.assign(this, partial);
-  }
-}
-
 export class UserInfoDto {
+  @ApiProperty({ description: 'User ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Username', example: 'admin' })
   username: string;
+
+  @ApiProperty({ description: 'User full name', example: 'John Doe' })
   name: string;
+
+  @ApiPropertyOptional({ description: 'User email', example: 'john.doe@hospital.com' })
   email?: string;
+
+  @ApiPropertyOptional({ description: 'Department', example: 'Internal Medicine' })
   department?: string;
+
+  @ApiPropertyOptional({ description: 'Position', example: 'Doctor' })
   position?: string;
+
+  @ApiProperty({ description: 'User roles', example: ['DOCTOR'], type: [String] })
   roles: string[];
+
+  @ApiProperty({
+    description: 'User permissions',
+    example: ['patient:read', 'patient:write'],
+    type: [String],
+  })
   permissions: string[];
 
   constructor(partial: Partial<UserInfoDto>) {
@@ -79,7 +99,20 @@ export class UserInfoDto {
   }
 }
 
+export class LoginResponseDto {
+  @ApiProperty({ description: 'User information', type: UserInfoDto })
+  user: UserInfoDto;
+
+  @ApiProperty({ description: 'Authentication tokens', type: TokenResponseDto })
+  tokens: TokenResponseDto;
+
+  constructor(partial: Partial<LoginResponseDto>) {
+    Object.assign(this, partial);
+  }
+}
+
 export class LogoutResponseDto {
+  @ApiProperty({ description: 'Logout message', example: 'Logged out successfully' })
   message: string;
 
   constructor(message: string = 'Logged out successfully') {
@@ -88,10 +121,15 @@ export class LogoutResponseDto {
 }
 
 export class ChangePasswordDto {
+  @ApiProperty({ description: 'Current password', example: 'OldPassword123!' })
   @IsString()
   @IsNotEmpty()
   currentPassword: string;
 
+  @ApiProperty({
+    description: 'New password (8+ chars, uppercase, lowercase, number, special char)',
+    example: 'NewPassword456!',
+  })
   @IsString()
   @IsNotEmpty()
   @MinLength(8)
@@ -100,6 +138,7 @@ export class ChangePasswordDto {
 }
 
 export class ChangePasswordResponseDto {
+  @ApiProperty({ description: 'Success message', example: 'Password changed successfully' })
   message: string;
 
   constructor(message: string = 'Password changed successfully') {

--- a/apps/backend/src/modules/auth/dto/session.dto.ts
+++ b/apps/backend/src/modules/auth/dto/session.dto.ts
@@ -1,62 +1,90 @@
 import { IsString, IsNotEmpty, IsArray, ValidateNested, IsEnum } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
 import { DeviceType } from '../interfaces';
 
 export class DeviceInfoDto {
+  @ApiProperty({ description: 'User agent string', example: 'Mozilla/5.0...' })
   @IsString()
   @IsNotEmpty()
   userAgent: string;
 
+  @ApiProperty({ description: 'Device type', enum: ['PC', 'TABLET', 'MOBILE'], example: 'PC' })
   @IsEnum(['PC', 'TABLET', 'MOBILE'])
   deviceType: DeviceType;
 
+  @ApiProperty({ description: 'Browser name', example: 'Chrome' })
   @IsString()
   @IsNotEmpty()
   browser: string;
 
+  @ApiProperty({ description: 'Operating system', example: 'Windows' })
   @IsString()
   @IsNotEmpty()
   os: string;
 }
 
 export class CreateSessionDto {
+  @ApiProperty({ description: 'User ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   @IsString()
   @IsNotEmpty()
   userId: string;
 
+  @ApiProperty({ description: 'Username', example: 'admin' })
   @IsString()
   @IsNotEmpty()
   username: string;
 
+  @ApiProperty({ description: 'User roles', example: ['ADMIN'], type: [String] })
   @IsArray()
   @IsString({ each: true })
   roles: string[];
 
+  @ApiProperty({ description: 'Device information', type: DeviceInfoDto })
   @ValidateNested()
   @Type(() => DeviceInfoDto)
   deviceInfo: DeviceInfoDto;
 
+  @ApiProperty({ description: 'Client IP address', example: '192.168.1.1' })
   @IsString()
   @IsNotEmpty()
   ipAddress: string;
 }
 
 export class SessionInfoResponseDto {
+  @ApiProperty({ description: 'Session ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   sessionId: string;
+
+  @ApiProperty({ description: 'Device information', type: DeviceInfoDto })
   deviceInfo: DeviceInfoDto;
+
+  @ApiProperty({ description: 'Client IP address', example: '192.168.1.1' })
   ipAddress: string;
+
+  @ApiProperty({ description: 'Session creation time' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Last activity time' })
   lastActivity: Date;
+
+  @ApiProperty({ description: 'Whether this is the current session', example: true })
   isCurrent: boolean;
 }
 
 export class DestroySessionDto {
+  @ApiProperty({
+    description: 'Session ID to destroy',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsString()
   @IsNotEmpty()
   sessionId: string;
 }
 
 export class SessionListResponseDto {
+  @ApiProperty({ description: 'List of sessions', type: [SessionInfoResponseDto] })
   sessions: SessionInfoResponseDto[];
+
+  @ApiProperty({ description: 'Total number of sessions', example: 3 })
   total: number;
 }

--- a/apps/backend/src/modules/patient/dto/create-patient-detail.dto.ts
+++ b/apps/backend/src/modules/patient/dto/create-patient-detail.dto.ts
@@ -1,32 +1,40 @@
 import { IsOptional, IsString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreatePatientDetailDto {
+  @ApiPropertyOptional({ description: 'Social Security Number' })
   @IsOptional()
   @IsString()
   ssn?: string;
 
+  @ApiPropertyOptional({ description: 'Medical history' })
   @IsOptional()
   @IsString()
   medicalHistory?: string;
 
+  @ApiPropertyOptional({ description: 'Known allergies' })
   @IsOptional()
   @IsString()
   allergies?: string;
 
+  @ApiPropertyOptional({ description: 'Insurance type', maxLength: 50 })
   @IsOptional()
   @IsString()
   @MaxLength(50)
   insuranceType?: string;
 
+  @ApiPropertyOptional({ description: 'Insurance number' })
   @IsOptional()
   @IsString()
   insuranceNumber?: string;
 
+  @ApiPropertyOptional({ description: 'Insurance company', maxLength: 100 })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   insuranceCompany?: string;
 
+  @ApiPropertyOptional({ description: 'Additional notes' })
   @IsOptional()
   @IsString()
   notes?: string;

--- a/apps/backend/src/modules/patient/dto/create-patient.dto.ts
+++ b/apps/backend/src/modules/patient/dto/create-patient.dto.ts
@@ -7,53 +7,80 @@ import {
   MaxLength,
   Matches,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender } from '@prisma/client';
 
 export class CreatePatientDto {
+  @ApiProperty({ description: 'Patient full name', example: 'John Doe', maxLength: 100 })
   @IsNotEmpty()
   @IsString()
   @MaxLength(100)
   name: string;
 
+  @ApiProperty({ description: 'Date of birth', example: '1990-01-15', format: 'date' })
   @IsNotEmpty()
   @IsDateString()
   birthDate: string;
 
+  @ApiProperty({ description: 'Patient gender', enum: ['MALE', 'FEMALE'], example: 'MALE' })
   @IsNotEmpty()
   @IsEnum(Gender)
   gender: Gender;
 
+  @ApiPropertyOptional({ description: 'Blood type', example: 'A+', maxLength: 10 })
   @IsOptional()
   @IsString()
   @MaxLength(10)
   bloodType?: string;
 
+  @ApiPropertyOptional({ description: 'Phone number', example: '010-1234-5678', maxLength: 20 })
   @IsOptional()
   @IsString()
   @MaxLength(20)
   @Matches(/^[0-9-]+$/, { message: 'Phone must contain only numbers and hyphens' })
   phone?: string;
 
+  @ApiPropertyOptional({ description: 'Address', example: '123 Main St, Seoul' })
   @IsOptional()
   @IsString()
   address?: string;
 
+  @ApiPropertyOptional({
+    description: 'Emergency contact name',
+    example: 'Jane Doe',
+    maxLength: 100,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   emergencyContactName?: string;
 
+  @ApiPropertyOptional({
+    description: 'Emergency contact phone',
+    example: '010-9876-5432',
+    maxLength: 20,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(20)
   @Matches(/^[0-9-]+$/, { message: 'Phone must contain only numbers and hyphens' })
   emergencyContactPhone?: string;
 
+  @ApiPropertyOptional({
+    description: 'Emergency contact relation',
+    example: 'Spouse',
+    maxLength: 50,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(50)
   emergencyContactRelation?: string;
 
+  @ApiPropertyOptional({
+    description: 'Legacy patient ID from previous system',
+    example: 'OLD-001',
+    maxLength: 50,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(50)

--- a/apps/backend/src/modules/patient/dto/find-patients.dto.ts
+++ b/apps/backend/src/modules/patient/dto/find-patients.dto.ts
@@ -1,30 +1,37 @@
 import { IsOptional, IsString, IsEnum, IsInt, Min, Max, IsIn } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender } from '@prisma/client';
 
 export class FindPatientsDto {
+  @ApiPropertyOptional({ description: 'Search query for name or patient number' })
   @IsOptional()
   @IsString()
   search?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by name' })
   @IsOptional()
   @IsString()
   name?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by patient number' })
   @IsOptional()
   @IsString()
   patientNumber?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by gender', enum: ['MALE', 'FEMALE'] })
   @IsOptional()
   @IsEnum(Gender)
   gender?: Gender;
 
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({ description: 'Items per page', default: 20, minimum: 1, maximum: 100 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -32,10 +39,12 @@ export class FindPatientsDto {
   @Max(100)
   limit?: number = 20;
 
+  @ApiPropertyOptional({ description: 'Sort field', default: 'createdAt' })
   @IsOptional()
   @IsString()
   sortBy?: string = 'createdAt';
 
+  @ApiPropertyOptional({ description: 'Sort order', enum: ['asc', 'desc'], default: 'desc' })
   @IsOptional()
   @IsIn(['asc', 'desc'])
   sortOrder?: 'asc' | 'desc' = 'desc';

--- a/apps/backend/src/modules/patient/dto/patient-response.dto.ts
+++ b/apps/backend/src/modules/patient/dto/patient-response.dto.ts
@@ -1,38 +1,95 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender } from '@prisma/client';
 
 export class PatientDetailResponseDto {
+  @ApiProperty({ description: 'Detail ID' })
   id: string;
+
+  @ApiPropertyOptional({ description: 'Social Security Number (masked)', nullable: true })
   ssn: string | null;
+
+  @ApiPropertyOptional({ description: 'Medical history', nullable: true })
   medicalHistory: string | null;
+
+  @ApiPropertyOptional({ description: 'Known allergies', nullable: true })
   allergies: string | null;
+
+  @ApiPropertyOptional({ description: 'Insurance type', nullable: true })
   insuranceType: string | null;
+
+  @ApiPropertyOptional({ description: 'Insurance number', nullable: true })
   insuranceNumber: string | null;
+
+  @ApiPropertyOptional({ description: 'Insurance company', nullable: true })
   insuranceCompany: string | null;
+
+  @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
 }
 
 export class PatientResponseDto {
+  @ApiProperty({ description: 'Patient ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Patient number', example: 'P2025000001' })
   patientNumber: string;
+
+  @ApiProperty({ description: 'Patient name', example: 'John Doe' })
   name: string;
+
+  @ApiProperty({ description: 'Birth date' })
   birthDate: Date;
+
+  @ApiProperty({ description: 'Gender', enum: ['MALE', 'FEMALE'] })
   gender: Gender;
+
+  @ApiPropertyOptional({ description: 'Blood type', nullable: true })
   bloodType: string | null;
+
+  @ApiPropertyOptional({ description: 'Phone number', nullable: true })
   phone: string | null;
+
+  @ApiPropertyOptional({ description: 'Address', nullable: true })
   address: string | null;
+
+  @ApiPropertyOptional({ description: 'Emergency contact name', nullable: true })
   emergencyContactName: string | null;
+
+  @ApiPropertyOptional({ description: 'Emergency contact phone', nullable: true })
   emergencyContactPhone: string | null;
+
+  @ApiPropertyOptional({ description: 'Emergency contact relation', nullable: true })
   emergencyContactRelation: string | null;
+
+  @ApiPropertyOptional({ description: 'Legacy patient ID', nullable: true })
   legacyPatientId: string | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
   updatedAt: Date;
+
+  @ApiPropertyOptional({
+    description: 'Patient detail information',
+    type: PatientDetailResponseDto,
+  })
   detail?: PatientDetailResponseDto;
 }
 
 export class PaginatedPatientsResponseDto {
+  @ApiProperty({ description: 'Patient list', type: [PatientResponseDto] })
   data: PatientResponseDto[];
+
+  @ApiProperty({ description: 'Total count', example: 100 })
   total: number;
+
+  @ApiProperty({ description: 'Current page', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total pages', example: 5 })
   totalPages: number;
 }

--- a/apps/backend/src/modules/patient/dto/update-patient-detail.dto.ts
+++ b/apps/backend/src/modules/patient/dto/update-patient-detail.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreatePatientDetailDto } from './create-patient-detail.dto';
 
 export class UpdatePatientDetailDto extends PartialType(CreatePatientDetailDto) {}

--- a/apps/backend/src/modules/patient/dto/update-patient.dto.ts
+++ b/apps/backend/src/modules/patient/dto/update-patient.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreatePatientDto } from './create-patient.dto';
 
 export class UpdatePatientDto extends PartialType(CreatePatientDto) {}

--- a/apps/backend/src/modules/patient/patient.controller.ts
+++ b/apps/backend/src/modules/patient/patient.controller.ts
@@ -11,6 +11,14 @@ import {
   HttpStatus,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { PatientService } from './patient.service';
 import { ParseUUIDPipe, CurrentUser } from '../../common';
 import { JwtAuthGuard } from '../../common/guards';
@@ -34,11 +42,16 @@ interface AuthenticatedUser {
   role: UserRole;
 }
 
+@ApiTags('patients')
+@ApiBearerAuth()
 @Controller('patients')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class PatientController {
   constructor(private readonly patientService: PatientService) {}
 
+  @ApiOperation({ summary: 'Create new patient' })
+  @ApiResponse({ status: 201, description: 'Patient created', type: PatientResponseDto })
+  @ApiResponse({ status: 403, description: 'Permission denied' })
   @Post()
   @RequirePermission(Permissions.PATIENT_CREATE)
   async create(
@@ -48,6 +61,12 @@ export class PatientController {
     return this.patientService.create(dto);
   }
 
+  @ApiOperation({ summary: 'Get patient list' })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated patient list',
+    type: PaginatedPatientsResponseDto,
+  })
   @Get()
   @RequirePermission(Permissions.PATIENT_READ)
   async findAll(
@@ -57,6 +76,9 @@ export class PatientController {
     return this.patientService.findAll(dto, user.role);
   }
 
+  @ApiOperation({ summary: 'Search patients by name or number' })
+  @ApiQuery({ name: 'q', description: 'Search query', required: false })
+  @ApiResponse({ status: 200, description: 'Search results', type: [PatientResponseDto] })
   @Get('search')
   @RequirePermission(Permissions.PATIENT_READ)
   async search(
@@ -66,6 +88,10 @@ export class PatientController {
     return this.patientService.search(query || '', user.role);
   }
 
+  @ApiOperation({ summary: 'Find patient by patient number' })
+  @ApiParam({ name: 'patientNumber', description: 'Patient number' })
+  @ApiResponse({ status: 200, description: 'Patient found', type: PatientResponseDto })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Get('by-number/:patientNumber')
   @RequirePermission(Permissions.PATIENT_READ)
   async findByPatientNumber(
@@ -75,6 +101,10 @@ export class PatientController {
     return this.patientService.findByPatientNumber(patientNumber, user.role);
   }
 
+  @ApiOperation({ summary: 'Find patient by legacy ID' })
+  @ApiParam({ name: 'legacyId', description: 'Legacy patient ID' })
+  @ApiResponse({ status: 200, description: 'Patient found', type: PatientResponseDto })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Get('by-legacy-id/:legacyId')
   @RequirePermission(Permissions.PATIENT_READ)
   async findByLegacyId(
@@ -84,6 +114,10 @@ export class PatientController {
     return this.patientService.findByLegacyId(legacyId, user.role);
   }
 
+  @ApiOperation({ summary: 'Get patient by ID' })
+  @ApiParam({ name: 'id', description: 'Patient ID' })
+  @ApiResponse({ status: 200, description: 'Patient found', type: PatientResponseDto })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Get(':id')
   @RequirePermission(Permissions.PATIENT_READ)
   async findById(
@@ -93,6 +127,10 @@ export class PatientController {
     return this.patientService.findById(id, user.role);
   }
 
+  @ApiOperation({ summary: 'Update patient' })
+  @ApiParam({ name: 'id', description: 'Patient ID' })
+  @ApiResponse({ status: 200, description: 'Patient updated', type: PatientResponseDto })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Patch(':id')
   @RequirePermission(Permissions.PATIENT_UPDATE)
   async update(
@@ -103,6 +141,11 @@ export class PatientController {
     return this.patientService.update(id, dto);
   }
 
+  @ApiOperation({ summary: 'Soft delete patient (Admin only)' })
+  @ApiParam({ name: 'id', description: 'Patient ID' })
+  @ApiResponse({ status: 204, description: 'Patient deleted' })
+  @ApiResponse({ status: 403, description: 'Admin role required' })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Delete(':id')
   @RequireRole('ADMIN')
   @HttpCode(HttpStatus.NO_CONTENT)
@@ -113,6 +156,10 @@ export class PatientController {
     return this.patientService.softDelete(id);
   }
 
+  @ApiOperation({ summary: 'Create patient detail' })
+  @ApiParam({ name: 'id', description: 'Patient ID' })
+  @ApiResponse({ status: 201, description: 'Detail created', type: PatientDetailResponseDto })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
   @Post(':id/detail')
   @RequirePermission(Permissions.PATIENT_UPDATE)
   async createDetail(
@@ -123,6 +170,10 @@ export class PatientController {
     return this.patientService.createDetail(id, dto);
   }
 
+  @ApiOperation({ summary: 'Update patient detail' })
+  @ApiParam({ name: 'id', description: 'Patient ID' })
+  @ApiResponse({ status: 200, description: 'Detail updated', type: PatientDetailResponseDto })
+  @ApiResponse({ status: 404, description: 'Patient or detail not found' })
   @Patch(':id/detail')
   @RequirePermission(Permissions.PATIENT_UPDATE)
   async updateDetail(

--- a/apps/backend/src/modules/report/daily-report-aggregator.service.ts
+++ b/apps/backend/src/modules/report/daily-report-aggregator.service.ts
@@ -22,7 +22,7 @@ import {
   MedicationComplianceDto,
   SignificantNoteDto,
   DailyAlertDto,
-  StatsSummary,
+  StatsSummaryDto,
   ListDailyReportsDto,
 } from './dto/daily-report.dto';
 import { AdmissionNotFoundException } from './exceptions';
@@ -272,7 +272,7 @@ export class DailyReportAggregatorService {
   /**
    * Calculate statistics for an array of numbers
    */
-  private calculateStats(values: number[]): StatsSummary | null {
+  private calculateStats(values: number[]): StatsSummaryDto | null {
     if (values.length === 0) {
       return null;
     }

--- a/apps/backend/src/modules/report/daily-report.controller.ts
+++ b/apps/backend/src/modules/report/daily-report.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { DailyReportAggregatorService } from './daily-report-aggregator.service';
 import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
@@ -16,6 +17,8 @@ import {
  * Reference: SDS Section 4.5.3 (Daily Report Aggregation Service)
  * Requirements: REQ-FR-040
  */
+@ApiTags('daily-reports')
+@ApiBearerAuth()
 @Controller('admissions/:admissionId/daily-reports')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class DailyReportController {
@@ -25,6 +28,13 @@ export class DailyReportController {
    * Get daily report for a specific date
    * GET /admissions/:admissionId/daily-reports/:date
    */
+  @ApiOperation({ summary: 'Get daily report for a specific date' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'date', description: 'Date in YYYY-MM-DD format' })
+  @ApiResponse({ status: 200, description: 'Daily report retrieved', type: DailyReportResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission or report not found' })
   @Get(':date')
   @RequirePermission('report:read')
   async getReport(
@@ -40,6 +50,17 @@ export class DailyReportController {
    * Generate or regenerate daily report for a specific date
    * POST /admissions/:admissionId/daily-reports/:date/generate
    */
+  @ApiOperation({ summary: 'Generate or regenerate daily report for a specific date' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'date', description: 'Date in YYYY-MM-DD format' })
+  @ApiResponse({
+    status: 201,
+    description: 'Daily report generated successfully',
+    type: DailyReportResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Post(':date/generate')
   @RequirePermission('report:write')
   async generateReport(
@@ -56,6 +77,17 @@ export class DailyReportController {
    * Get live daily summary (without saving)
    * GET /admissions/:admissionId/daily-reports/:date/summary
    */
+  @ApiOperation({ summary: 'Get live daily summary without saving' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'date', description: 'Date in YYYY-MM-DD format' })
+  @ApiResponse({
+    status: 200,
+    description: 'Daily summary retrieved',
+    type: DailySummaryResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get(':date/summary')
   @RequirePermission('report:read')
   async getSummary(
@@ -71,6 +103,16 @@ export class DailyReportController {
    * List all daily reports for an admission
    * GET /admissions/:admissionId/daily-reports
    */
+  @ApiOperation({ summary: 'List all daily reports for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Daily reports list retrieved',
+    type: PaginatedDailyReportsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get()
   @RequirePermission('report:read')
   async listReports(

--- a/apps/backend/src/modules/report/dto/daily-report.dto.ts
+++ b/apps/backend/src/modules/report/dto/daily-report.dto.ts
@@ -1,101 +1,211 @@
 import { IsDateString, IsOptional, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PatientStatus } from '@prisma/client';
 
 /**
  * Vital signs statistics summary
  */
-export interface StatsSummary {
+export class StatsSummaryDto {
+  @ApiProperty({ description: 'Minimum value', example: 36.0 })
   min: number;
+
+  @ApiProperty({ description: 'Maximum value', example: 37.2 })
   max: number;
+
+  @ApiProperty({ description: 'Average value', example: 36.5 })
   avg: number;
+
+  @ApiProperty({ description: 'Number of measurements', example: 12 })
   count: number;
 }
 
 /**
  * Blood pressure statistics
  */
-export interface BloodPressureStats {
-  systolic: StatsSummary | null;
-  diastolic: StatsSummary | null;
+export class BloodPressureStatsDto {
+  @ApiPropertyOptional({
+    description: 'Systolic blood pressure statistics',
+    type: StatsSummaryDto,
+    nullable: true,
+  })
+  systolic: StatsSummaryDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Diastolic blood pressure statistics',
+    type: StatsSummaryDto,
+    nullable: true,
+  })
+  diastolic: StatsSummaryDto | null;
 }
 
 /**
  * Vitals summary for daily report
  */
-export interface VitalsSummaryDto {
+export class VitalsSummaryDto {
+  @ApiProperty({ description: 'Number of vital sign measurements', example: 12 })
   measurementCount: number;
-  temperature: StatsSummary | null;
-  bloodPressure: BloodPressureStats;
-  pulseRate: StatsSummary | null;
-  respiratoryRate: StatsSummary | null;
-  oxygenSaturation: StatsSummary | null;
+
+  @ApiPropertyOptional({
+    description: 'Temperature statistics',
+    type: StatsSummaryDto,
+    nullable: true,
+  })
+  temperature: StatsSummaryDto | null;
+
+  @ApiProperty({ description: 'Blood pressure statistics', type: BloodPressureStatsDto })
+  bloodPressure: BloodPressureStatsDto;
+
+  @ApiPropertyOptional({
+    description: 'Pulse rate statistics',
+    type: StatsSummaryDto,
+    nullable: true,
+  })
+  pulseRate: StatsSummaryDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Respiratory rate statistics',
+    type: StatsSummaryDto,
+    nullable: true,
+  })
+  respiratoryRate: StatsSummaryDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Oxygen saturation statistics',
+    type: StatsSummaryDto,
+    nullable: true,
+  })
+  oxygenSaturation: StatsSummaryDto | null;
+
+  @ApiProperty({ description: 'Number of vital sign alerts', example: 2 })
   alertCount: number;
 }
 
 /**
- * Intake breakdown
+ * Intake breakdown for daily report
  */
-export interface IntakeBreakdownDto {
+export class DailyIntakeBreakdownDto {
+  @ApiProperty({ description: 'Oral intake in mL', example: 1500 })
   oral: number;
+
+  @ApiProperty({ description: 'IV intake in mL', example: 2000 })
   iv: number;
+
+  @ApiProperty({ description: 'Tube feeding in mL', example: 0 })
   tubeFeeding: number;
+
+  @ApiProperty({ description: 'Other intake in mL', example: 0 })
   other: number;
+
+  @ApiProperty({ description: 'Total intake in mL', example: 3500 })
   total: number;
 }
 
 /**
- * Output breakdown
+ * Output breakdown for daily report
  */
-export interface OutputBreakdownDto {
+export class DailyOutputBreakdownDto {
+  @ApiProperty({ description: 'Urine output in mL', example: 2000 })
   urine: number;
+
+  @ApiProperty({ description: 'Stool output in mL', example: 300 })
   stool: number;
+
+  @ApiProperty({ description: 'Vomit output in mL', example: 0 })
   vomit: number;
+
+  @ApiProperty({ description: 'Drainage output in mL', example: 0 })
   drainage: number;
+
+  @ApiProperty({ description: 'Other output in mL', example: 0 })
   other: number;
+
+  @ApiProperty({ description: 'Total output in mL', example: 2300 })
   total: number;
 }
 
 /**
  * I/O balance summary
  */
-export interface IOBalanceSummaryDto {
-  intake: IntakeBreakdownDto;
-  output: OutputBreakdownDto;
+export class IOBalanceSummaryDto {
+  @ApiProperty({ description: 'Intake breakdown', type: DailyIntakeBreakdownDto })
+  intake: DailyIntakeBreakdownDto;
+
+  @ApiProperty({ description: 'Output breakdown', type: DailyOutputBreakdownDto })
+  output: DailyOutputBreakdownDto;
+
+  @ApiProperty({ description: 'I/O balance in mL', example: 1200 })
   balance: number;
+
+  @ApiProperty({
+    description: 'Balance status',
+    enum: ['NORMAL', 'POSITIVE', 'NEGATIVE'],
+    example: 'POSITIVE',
+  })
   status: 'NORMAL' | 'POSITIVE' | 'NEGATIVE';
 }
 
 /**
  * Medication compliance summary
  */
-export interface MedicationComplianceDto {
+export class MedicationComplianceDto {
+  @ApiProperty({ description: 'Number of scheduled medications', example: 10 })
   scheduled: number;
+
+  @ApiProperty({ description: 'Number of administered medications', example: 8 })
   administered: number;
+
+  @ApiProperty({ description: 'Number of held medications', example: 1 })
   held: number;
+
+  @ApiProperty({ description: 'Number of refused medications', example: 1 })
   refused: number;
+
+  @ApiProperty({ description: 'Number of missed medications', example: 0 })
   missed: number;
+
+  @ApiProperty({ description: 'Compliance rate as percentage', example: 80.0 })
   complianceRate: number;
 }
 
 /**
  * Alert item for daily report
  */
-export interface DailyAlertDto {
+export class DailyAlertDto {
+  @ApiProperty({ description: 'Type of alert', example: 'VITAL_SIGN' })
   type: string;
+
+  @ApiProperty({
+    description: 'Severity level',
+    enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+    example: 'HIGH',
+  })
   severity: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+  @ApiProperty({ description: 'Value that triggered the alert', example: 38.5 })
   value: number;
+
+  @ApiProperty({ description: 'Alert message', example: 'Temperature elevated: 38.5C' })
   message: string;
+
+  @ApiProperty({ description: 'Time when the alert was recorded' })
   recordedAt: Date;
 }
 
 /**
  * Significant note summary
  */
-export interface SignificantNoteDto {
+export class SignificantNoteDto {
+  @ApiProperty({ description: 'Note ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Type of note', example: 'PROGRESS' })
   noteType: string;
+
+  @ApiProperty({ description: 'Note summary', example: 'Patient condition improving' })
   summary: string;
+
+  @ApiProperty({ description: 'Time when the note was recorded' })
   recordedAt: Date;
 }
 
@@ -103,13 +213,32 @@ export interface SignificantNoteDto {
  * Daily summary response
  */
 export class DailySummaryResponseDto {
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   admissionId: string;
+
+  @ApiProperty({ description: 'Date of the summary' })
   date: Date;
+
+  @ApiPropertyOptional({ description: 'Vitals summary', type: VitalsSummaryDto, nullable: true })
   vitalsSummary: VitalsSummaryDto | null;
+
+  @ApiPropertyOptional({
+    description: 'I/O balance summary',
+    type: IOBalanceSummaryDto,
+    nullable: true,
+  })
   ioBalance: IOBalanceSummaryDto | null;
+
+  @ApiProperty({ description: 'Medication compliance summary', type: MedicationComplianceDto })
   medicationCompliance: MedicationComplianceDto;
+
+  @ApiProperty({ description: 'List of significant notes', type: [SignificantNoteDto] })
   significantNotes: SignificantNoteDto[];
+
+  @ApiProperty({ description: 'List of alerts', type: [DailyAlertDto] })
   alerts: DailyAlertDto[];
+
+  @ApiPropertyOptional({ description: 'Patient status', enum: PatientStatus, nullable: true })
   patientStatus: PatientStatus | null;
 }
 
@@ -117,19 +246,46 @@ export class DailySummaryResponseDto {
  * Daily report response (stored report)
  */
 export class DailyReportResponseDto {
+  @ApiProperty({ description: 'Report ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   admissionId: string;
+
+  @ApiProperty({ description: 'Report date' })
   reportDate: Date;
+
+  @ApiPropertyOptional({ description: 'Vitals summary', type: VitalsSummaryDto, nullable: true })
   vitalsSummary: VitalsSummaryDto | null;
+
+  @ApiPropertyOptional({ description: 'Total intake in mL', example: 3500, nullable: true })
   totalIntake: number | null;
+
+  @ApiPropertyOptional({ description: 'Total output in mL', example: 2300, nullable: true })
   totalOutput: number | null;
+
+  @ApiPropertyOptional({ description: 'I/O balance in mL', example: 1200, nullable: true })
   ioBalance: number | null;
+
+  @ApiPropertyOptional({ description: 'Number of medications given', example: 8, nullable: true })
   medicationsGiven: number | null;
+
+  @ApiPropertyOptional({ description: 'Number of medications held', example: 1, nullable: true })
   medicationsHeld: number | null;
+
+  @ApiPropertyOptional({ description: 'Patient status', enum: PatientStatus, nullable: true })
   patientStatus: PatientStatus | null;
+
+  @ApiPropertyOptional({ description: 'Summary text', nullable: true })
   summary: string | null;
+
+  @ApiPropertyOptional({ description: 'List of alerts', type: [DailyAlertDto], nullable: true })
   alerts: DailyAlertDto[] | null;
+
+  @ApiProperty({ description: 'Time when the report was generated' })
   generatedAt: Date;
+
+  @ApiPropertyOptional({ description: 'User ID who generated the report', nullable: true })
   generatedBy: string | null;
 }
 
@@ -137,10 +293,19 @@ export class DailyReportResponseDto {
  * Paginated daily reports response
  */
 export class PaginatedDailyReportsResponseDto {
+  @ApiProperty({ description: 'Array of daily reports', type: [DailyReportResponseDto] })
   data: DailyReportResponseDto[];
+
+  @ApiProperty({ description: 'Total number of records', example: 30 })
   total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 2 })
   totalPages: number;
 }
 
@@ -148,6 +313,7 @@ export class PaginatedDailyReportsResponseDto {
  * DTO for generating/regenerating daily report
  */
 export class GenerateDailyReportDto {
+  @ApiProperty({ description: 'Date for the report', example: '2024-01-15' })
   @IsDateString()
   date: string;
 }
@@ -156,20 +322,30 @@ export class GenerateDailyReportDto {
  * DTO for listing daily reports
  */
 export class ListDailyReportsDto {
+  @ApiPropertyOptional({ description: 'Start date filter', example: '2024-01-01' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date filter', example: '2024-01-31' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -182,7 +358,12 @@ export class ListDailyReportsDto {
  * Batch generation result
  */
 export class BatchGenerationResultDto {
+  @ApiProperty({ description: 'Number of reports generated', example: 5 })
   generatedCount: number;
+
+  @ApiProperty({ description: 'Date for which reports were generated' })
   date: Date;
+
+  @ApiProperty({ description: 'Time when generation completed' })
   generatedAt: Date;
 }

--- a/apps/backend/src/modules/report/dto/get-io-history.dto.ts
+++ b/apps/backend/src/modules/report/dto/get-io-history.dto.ts
@@ -1,24 +1,35 @@
 import { IsOptional, IsDateString, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * DTO for querying I/O history
  */
 export class GetIOHistoryDto {
+  @ApiPropertyOptional({ description: 'Start date filter', example: '2024-01-01' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date filter', example: '2024-01-31' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -31,9 +42,11 @@ export class GetIOHistoryDto {
  * DTO for querying I/O balance history
  */
 export class GetIOBalanceDto {
+  @ApiProperty({ description: 'Start date for balance history', example: '2024-01-01' })
   @IsDateString()
   startDate: string;
 
+  @ApiProperty({ description: 'End date for balance history', example: '2024-01-31' })
   @IsDateString()
   endDate: string;
 }

--- a/apps/backend/src/modules/report/dto/get-trend.dto.ts
+++ b/apps/backend/src/modules/report/dto/get-trend.dto.ts
@@ -1,13 +1,16 @@
 import { IsDateString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * DTO for querying vital signs trend data (REQ-FR-032)
  */
 export class GetTrendDto {
+  @ApiProperty({ description: 'Start date for trend data', example: '2024-01-01' })
   @IsNotEmpty()
   @IsDateString()
   startDate: string;
 
+  @ApiProperty({ description: 'End date for trend data', example: '2024-01-31' })
   @IsNotEmpty()
   @IsDateString()
   endDate: string;

--- a/apps/backend/src/modules/report/dto/get-vital-history.dto.ts
+++ b/apps/backend/src/modules/report/dto/get-vital-history.dto.ts
@@ -1,29 +1,41 @@
 import { IsOptional, IsInt, Min, Max, IsDateString, IsBoolean } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * DTO for querying vital sign history (REQ-FR-031)
  */
 export class GetVitalHistoryDto {
+  @ApiPropertyOptional({ description: 'Start date filter', example: '2024-01-01' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date filter', example: '2024-01-31' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by alert status', example: true })
   @IsOptional()
   @Transform(({ value }) => value === 'true' || value === true)
   @IsBoolean()
   hasAlert?: boolean;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/apps/backend/src/modules/report/dto/io-response.dto.ts
+++ b/apps/backend/src/modules/report/dto/io-response.dto.ts
@@ -1,40 +1,124 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
 /**
  * Response DTO for IntakeOutput record
  */
 export class IntakeOutputResponseDto {
+  @ApiProperty({ description: 'I/O record ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   admissionId: string;
+
+  @ApiProperty({ description: 'Date of the record' })
   recordDate: Date;
+
+  @ApiProperty({ description: 'Time of the record' })
   recordTime: Date;
 
   // Intake
+  @ApiProperty({ description: 'Oral intake in mL', example: 500 })
   oralIntake: number;
+
+  @ApiProperty({ description: 'IV intake in mL', example: 1000 })
   ivIntake: number;
+
+  @ApiProperty({ description: 'Tube feeding in mL', example: 0 })
   tubeFeeding: number;
+
+  @ApiProperty({ description: 'Other intake in mL', example: 0 })
   otherIntake: number;
+
+  @ApiProperty({ description: 'Total intake in mL', example: 1500 })
   totalIntake: number;
 
   // Output
+  @ApiProperty({ description: 'Urine output in mL', example: 800 })
   urineOutput: number;
+
+  @ApiProperty({ description: 'Stool output in mL', example: 200 })
   stoolOutput: number;
+
+  @ApiProperty({ description: 'Vomit output in mL', example: 0 })
   vomitOutput: number;
+
+  @ApiProperty({ description: 'Drainage output in mL', example: 0 })
   drainageOutput: number;
+
+  @ApiProperty({ description: 'Other output in mL', example: 0 })
   otherOutput: number;
+
+  @ApiProperty({ description: 'Total output in mL', example: 1000 })
   totalOutput: number;
 
   // Balance
+  @ApiProperty({ description: 'I/O balance (intake - output) in mL', example: 500 })
   balance: number;
 
+  @ApiProperty({
+    description: 'User ID who recorded',
+    example: '550e8400-e29b-41d4-a716-446655440002',
+  })
   recordedBy: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'Record creation timestamp' })
   createdAt: Date;
+}
+
+/**
+ * Intake breakdown sub-DTO
+ */
+export class IntakeBreakdownDto {
+  @ApiProperty({ description: 'Oral intake in mL', example: 500 })
+  oral: number;
+
+  @ApiProperty({ description: 'IV intake in mL', example: 1000 })
+  iv: number;
+
+  @ApiProperty({ description: 'Tube feeding in mL', example: 0 })
+  tubeFeeding: number;
+
+  @ApiProperty({ description: 'Other intake in mL', example: 0 })
+  other: number;
+
+  @ApiProperty({ description: 'Total intake in mL', example: 1500 })
+  total: number;
+}
+
+/**
+ * Output breakdown sub-DTO
+ */
+export class OutputBreakdownDto {
+  @ApiProperty({ description: 'Urine output in mL', example: 800 })
+  urine: number;
+
+  @ApiProperty({ description: 'Stool output in mL', example: 200 })
+  stool: number;
+
+  @ApiProperty({ description: 'Vomit output in mL', example: 0 })
+  vomit: number;
+
+  @ApiProperty({ description: 'Drainage output in mL', example: 0 })
+  drainage: number;
+
+  @ApiProperty({ description: 'Other output in mL', example: 0 })
+  other: number;
+
+  @ApiProperty({ description: 'Total output in mL', example: 1000 })
+  total: number;
 }
 
 /**
  * Daily I/O Summary response
  */
 export class IODailySummaryDto {
+  @ApiProperty({ description: 'Date of the summary' })
   date: Date;
+
+  @ApiProperty({ description: 'Intake breakdown', type: IntakeBreakdownDto })
   intake: {
     oral: number;
     iv: number;
@@ -42,6 +126,8 @@ export class IODailySummaryDto {
     other: number;
     total: number;
   };
+
+  @ApiProperty({ description: 'Output breakdown', type: OutputBreakdownDto })
   output: {
     urine: number;
     stool: number;
@@ -50,7 +136,15 @@ export class IODailySummaryDto {
     other: number;
     total: number;
   };
+
+  @ApiProperty({ description: 'I/O balance in mL', example: 500 })
   balance: number;
+
+  @ApiProperty({
+    description: 'Balance status',
+    enum: ['NORMAL', 'POSITIVE', 'NEGATIVE'],
+    example: 'NORMAL',
+  })
   status: 'NORMAL' | 'POSITIVE' | 'NEGATIVE';
 }
 
@@ -58,10 +152,23 @@ export class IODailySummaryDto {
  * I/O Balance for a date range
  */
 export class IOBalanceDto {
+  @ApiProperty({ description: 'Date of the balance record' })
   date: Date;
+
+  @ApiProperty({ description: 'Total intake in mL', example: 1500 })
   totalIntake: number;
+
+  @ApiProperty({ description: 'Total output in mL', example: 1000 })
   totalOutput: number;
+
+  @ApiProperty({ description: 'Balance in mL', example: 500 })
   balance: number;
+
+  @ApiProperty({
+    description: 'Balance status',
+    enum: ['NORMAL', 'POSITIVE', 'NEGATIVE'],
+    example: 'NORMAL',
+  })
   status: 'NORMAL' | 'POSITIVE' | 'NEGATIVE';
 }
 
@@ -69,9 +176,18 @@ export class IOBalanceDto {
  * Paginated I/O history response
  */
 export class PaginatedIOResponseDto {
+  @ApiProperty({ description: 'Array of I/O records', type: [IntakeOutputResponseDto] })
   data: IntakeOutputResponseDto[];
+
+  @ApiProperty({ description: 'Total number of records', example: 100 })
   total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 5 })
   totalPages: number;
 }

--- a/apps/backend/src/modules/report/dto/medication.dto.ts
+++ b/apps/backend/src/modules/report/dto/medication.dto.ts
@@ -9,32 +9,50 @@ import {
   MaxLength,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { MedicationRoute, MedicationStatus } from '@prisma/client';
 
 /**
  * DTO for scheduling medication
  */
 export class ScheduleMedicationDto {
+  @ApiProperty({
+    description: 'Name of the medication',
+    example: 'Amoxicillin 500mg',
+    maxLength: 255,
+  })
   @IsString()
   @MaxLength(255)
   medicationName: string;
 
+  @ApiProperty({ description: 'Dosage of the medication', example: '500mg', maxLength: 100 })
   @IsString()
   @MaxLength(100)
   dosage: string;
 
+  @ApiProperty({ description: 'Route of administration', enum: MedicationRoute, example: 'ORAL' })
   @IsEnum(MedicationRoute)
   route: MedicationRoute;
 
+  @ApiPropertyOptional({
+    description: 'Frequency of administration',
+    example: 'TID (Three times daily)',
+    maxLength: 100,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(100)
   frequency?: string;
 
+  @ApiPropertyOptional({
+    description: 'Scheduled time for administration',
+    example: '2024-01-15T08:00:00Z',
+  })
   @IsOptional()
   @IsDateString()
   scheduledTime?: string;
 
+  @ApiPropertyOptional({ description: 'Additional notes', example: 'Take with food' })
   @IsOptional()
   @IsString()
   notes?: string;
@@ -44,10 +62,15 @@ export class ScheduleMedicationDto {
  * DTO for administering medication
  */
 export class AdministerMedicationDto {
+  @ApiPropertyOptional({
+    description: 'Time when medication was administered',
+    example: '2024-01-15T08:15:00Z',
+  })
   @IsOptional()
   @IsDateString()
   administeredAt?: string;
 
+  @ApiPropertyOptional({ description: 'Additional notes', example: 'Patient tolerated well' })
   @IsOptional()
   @IsString()
   notes?: string;
@@ -57,6 +80,10 @@ export class AdministerMedicationDto {
  * DTO for holding medication
  */
 export class HoldMedicationDto {
+  @ApiProperty({
+    description: 'Reason for holding the medication',
+    example: 'Patient NPO for procedure',
+  })
   @IsString()
   reason: string;
 }
@@ -65,6 +92,10 @@ export class HoldMedicationDto {
  * DTO for refusing medication
  */
 export class RefuseMedicationDto {
+  @ApiProperty({
+    description: 'Reason for patient refusal',
+    example: 'Patient refuses due to nausea',
+  })
   @IsString()
   reason: string;
 }
@@ -73,24 +104,39 @@ export class RefuseMedicationDto {
  * DTO for querying medication history
  */
 export class GetMedicationHistoryDto {
+  @ApiPropertyOptional({ description: 'Start date filter', example: '2024-01-01' })
   @IsOptional()
   @IsDateString()
   startDate?: string;
 
+  @ApiPropertyOptional({ description: 'End date filter', example: '2024-01-31' })
   @IsOptional()
   @IsDateString()
   endDate?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by medication status',
+    enum: MedicationStatus,
+    example: 'ADMINISTERED',
+  })
   @IsOptional()
   @IsEnum(MedicationStatus)
   status?: MedicationStatus;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -103,18 +149,50 @@ export class GetMedicationHistoryDto {
  * Medication response DTO
  */
 export class MedicationResponseDto {
+  @ApiProperty({
+    description: 'Medication record ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   id: string;
+
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   admissionId: string;
+
+  @ApiProperty({ description: 'Name of the medication', example: 'Amoxicillin 500mg' })
   medicationName: string;
+
+  @ApiProperty({ description: 'Dosage', example: '500mg' })
   dosage: string;
+
+  @ApiProperty({ description: 'Route of administration', enum: MedicationRoute, example: 'ORAL' })
   route: MedicationRoute;
+
+  @ApiPropertyOptional({ description: 'Frequency of administration', nullable: true })
   frequency: string | null;
+
+  @ApiPropertyOptional({ description: 'Scheduled time for administration', nullable: true })
   scheduledTime: Date | null;
+
+  @ApiPropertyOptional({ description: 'Time when medication was administered', nullable: true })
   administeredAt: Date | null;
+
+  @ApiPropertyOptional({ description: 'User ID who administered the medication', nullable: true })
   administeredBy: string | null;
+
+  @ApiProperty({
+    description: 'Current status of the medication',
+    enum: MedicationStatus,
+    example: 'SCHEDULED',
+  })
   status: MedicationStatus;
+
+  @ApiPropertyOptional({ description: 'Reason for holding the medication', nullable: true })
   holdReason: string | null;
+
+  @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'Record creation timestamp' })
   createdAt: Date;
 }
 
@@ -122,9 +200,18 @@ export class MedicationResponseDto {
  * Paginated medication response
  */
 export class PaginatedMedicationResponseDto {
+  @ApiProperty({ description: 'Array of medication records', type: [MedicationResponseDto] })
   data: MedicationResponseDto[];
+
+  @ApiProperty({ description: 'Total number of records', example: 100 })
   total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 5 })
   totalPages: number;
 }

--- a/apps/backend/src/modules/report/dto/nursing-note.dto.ts
+++ b/apps/backend/src/modules/report/dto/nursing-note.dto.ts
@@ -1,30 +1,49 @@
 import { IsString, IsOptional, IsEnum, IsBoolean, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { NoteType } from '@prisma/client';
 
 /**
  * DTO for creating nursing note (SOAP format)
  */
 export class CreateNursingNoteDto {
+  @ApiProperty({ description: 'Type of nursing note', enum: NoteType, example: 'PROGRESS' })
   @IsEnum(NoteType)
   noteType: NoteType;
 
+  @ApiPropertyOptional({
+    description: 'Subjective - Patient complaints and symptoms',
+    example: 'Patient reports mild headache',
+  })
   @IsOptional()
   @IsString()
   subjective?: string; // S: Patient's complaints
 
+  @ApiPropertyOptional({
+    description: 'Objective - Observable findings',
+    example: 'Vital signs stable, patient appears comfortable',
+  })
   @IsOptional()
   @IsString()
   objective?: string; // O: Observable findings
 
+  @ApiPropertyOptional({
+    description: 'Assessment - Nursing assessment',
+    example: 'Mild tension headache, likely due to stress',
+  })
   @IsOptional()
   @IsString()
   assessment?: string; // A: Nursing assessment
 
+  @ApiPropertyOptional({
+    description: 'Plan - Care plan',
+    example: 'Continue monitoring, administer PRN analgesic if needed',
+  })
   @IsOptional()
   @IsString()
   plan?: string; // P: Care plan
 
+  @ApiProperty({ description: 'Whether the note is significant for handoff', example: false })
   @IsBoolean()
   isSignificant: boolean;
 }
@@ -33,21 +52,31 @@ export class CreateNursingNoteDto {
  * DTO for querying nursing notes
  */
 export class GetNursingNotesDto {
+  @ApiPropertyOptional({ description: 'Filter by note type', enum: NoteType, example: 'PROGRESS' })
   @IsOptional()
   @IsEnum(NoteType)
   noteType?: NoteType;
 
+  @ApiPropertyOptional({ description: 'Filter by significant notes only', example: true })
   @IsOptional()
   @Type(() => Boolean)
   @IsBoolean()
   isSignificant?: boolean;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
@@ -60,17 +89,43 @@ export class GetNursingNotesDto {
  * Nursing note response DTO
  */
 export class NursingNoteResponseDto {
+  @ApiProperty({ description: 'Nursing note ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   admissionId: string;
+
+  @ApiProperty({ description: 'Type of nursing note', enum: NoteType, example: 'PROGRESS' })
   noteType: NoteType;
+
+  @ApiPropertyOptional({ description: 'Subjective - Patient complaints', nullable: true })
   subjective: string | null;
+
+  @ApiPropertyOptional({ description: 'Objective - Observable findings', nullable: true })
   objective: string | null;
+
+  @ApiPropertyOptional({ description: 'Assessment - Nursing assessment', nullable: true })
   assessment: string | null;
+
+  @ApiPropertyOptional({ description: 'Plan - Care plan', nullable: true })
   plan: string | null;
+
+  @ApiProperty({ description: 'Time when note was recorded' })
   recordedAt: Date;
+
+  @ApiProperty({
+    description: 'User ID who recorded the note',
+    example: '550e8400-e29b-41d4-a716-446655440002',
+  })
   recordedBy: string;
+
+  @ApiProperty({ description: 'Whether the note is significant for handoff', example: false })
   isSignificant: boolean;
+
+  @ApiProperty({ description: 'Record creation timestamp' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Record last update timestamp' })
   updatedAt: Date;
 }
 
@@ -78,9 +133,18 @@ export class NursingNoteResponseDto {
  * Paginated nursing notes response
  */
 export class PaginatedNursingNotesResponseDto {
+  @ApiProperty({ description: 'Array of nursing notes', type: [NursingNoteResponseDto] })
   data: NursingNoteResponseDto[];
+
+  @ApiProperty({ description: 'Total number of records', example: 100 })
   total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 5 })
   totalPages: number;
 }

--- a/apps/backend/src/modules/report/dto/record-io.dto.ts
+++ b/apps/backend/src/modules/report/dto/record-io.dto.ts
@@ -1,62 +1,75 @@
 import { IsInt, IsOptional, IsString, IsDateString, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
  * DTO for recording intake/output (REQ-FR-036)
  */
 export class RecordIODto {
+  @ApiProperty({ description: 'Date of the record', example: '2024-01-15' })
   @IsDateString()
   recordDate: string;
 
+  @ApiProperty({ description: 'Time of the record', example: '2024-01-15T10:30:00Z' })
   @IsDateString()
   recordTime: string;
 
   // Intake
+  @ApiPropertyOptional({ description: 'Oral intake in mL', example: 500, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   oralIntake?: number;
 
+  @ApiPropertyOptional({ description: 'IV intake in mL', example: 1000, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   ivIntake?: number;
 
+  @ApiPropertyOptional({ description: 'Tube feeding in mL', example: 0, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   tubeFeeding?: number;
 
+  @ApiPropertyOptional({ description: 'Other intake in mL', example: 0, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   otherIntake?: number;
 
   // Output
+  @ApiPropertyOptional({ description: 'Urine output in mL', example: 800, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   urineOutput?: number;
 
+  @ApiPropertyOptional({ description: 'Stool output in mL', example: 200, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   stoolOutput?: number;
 
+  @ApiPropertyOptional({ description: 'Vomit output in mL', example: 0, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   vomitOutput?: number;
 
+  @ApiPropertyOptional({ description: 'Drainage output in mL', example: 0, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   drainageOutput?: number;
 
+  @ApiPropertyOptional({ description: 'Other output in mL', example: 0, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   otherOutput?: number;
 
+  @ApiPropertyOptional({ description: 'Additional notes', example: 'Patient drinking well' })
   @IsOptional()
   @IsString()
   notes?: string;

--- a/apps/backend/src/modules/report/dto/record-vital-signs.dto.ts
+++ b/apps/backend/src/modules/report/dto/record-vital-signs.dto.ts
@@ -8,67 +8,116 @@ import {
   IsString,
   IsDateString,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Consciousness } from '@prisma/client';
 
 /**
  * DTO for recording vital signs (REQ-FR-030)
  */
 export class RecordVitalSignsDto {
+  @ApiPropertyOptional({
+    description: 'Body temperature in Celsius',
+    example: 36.5,
+    minimum: 30,
+    maximum: 45,
+  })
   @IsOptional()
   @IsNumber()
   @Min(30)
   @Max(45)
   temperature?: number;
 
+  @ApiPropertyOptional({
+    description: 'Systolic blood pressure in mmHg',
+    example: 120,
+    minimum: 50,
+    maximum: 250,
+  })
   @IsOptional()
   @IsInt()
   @Min(50)
   @Max(250)
   systolicBp?: number;
 
+  @ApiPropertyOptional({
+    description: 'Diastolic blood pressure in mmHg',
+    example: 80,
+    minimum: 30,
+    maximum: 150,
+  })
   @IsOptional()
   @IsInt()
   @Min(30)
   @Max(150)
   diastolicBp?: number;
 
+  @ApiPropertyOptional({
+    description: 'Pulse rate in beats per minute',
+    example: 72,
+    minimum: 30,
+    maximum: 200,
+  })
   @IsOptional()
   @IsInt()
   @Min(30)
   @Max(200)
   pulseRate?: number;
 
+  @ApiPropertyOptional({
+    description: 'Respiratory rate in breaths per minute',
+    example: 16,
+    minimum: 5,
+    maximum: 60,
+  })
   @IsOptional()
   @IsInt()
   @Min(5)
   @Max(60)
   respiratoryRate?: number;
 
+  @ApiPropertyOptional({
+    description: 'Oxygen saturation percentage',
+    example: 98,
+    minimum: 50,
+    maximum: 100,
+  })
   @IsOptional()
   @IsInt()
   @Min(50)
   @Max(100)
   oxygenSaturation?: number;
 
+  @ApiPropertyOptional({ description: 'Blood glucose level in mg/dL', example: 100, minimum: 0 })
   @IsOptional()
   @IsInt()
   @Min(0)
   bloodGlucose?: number;
 
+  @ApiPropertyOptional({ description: 'Pain score (0-10)', example: 3, minimum: 0, maximum: 10 })
   @IsOptional()
   @IsInt()
   @Min(0)
   @Max(10)
   painScore?: number;
 
+  @ApiPropertyOptional({
+    description: 'Consciousness level',
+    enum: Consciousness,
+    example: 'ALERT',
+  })
   @IsOptional()
   @IsEnum(Consciousness)
   consciousness?: Consciousness;
 
+  @ApiPropertyOptional({ description: 'Additional notes', example: 'Patient reports feeling well' })
   @IsOptional()
   @IsString()
   notes?: string;
 
+  @ApiPropertyOptional({
+    description: 'Time when vitals were measured',
+    example: '2024-01-15T10:30:00Z',
+  })
   @IsOptional()
   @IsDateString()
   measuredAt?: string;

--- a/apps/backend/src/modules/report/dto/vital-sign-response.dto.ts
+++ b/apps/backend/src/modules/report/dto/vital-sign-response.dto.ts
@@ -1,3 +1,4 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Consciousness } from '@prisma/client';
 import { VitalAlert } from '../value-objects';
 
@@ -5,22 +6,85 @@ import { VitalAlert } from '../value-objects';
  * Response DTO for vital sign record
  */
 export class VitalSignResponseDto {
+  @ApiProperty({
+    description: 'Vital sign record ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   id: string;
+
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   admissionId: string;
+
+  @ApiPropertyOptional({
+    description: 'Body temperature in Celsius',
+    example: 36.5,
+    nullable: true,
+  })
   temperature: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Systolic blood pressure in mmHg',
+    example: 120,
+    nullable: true,
+  })
   systolicBp: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Diastolic blood pressure in mmHg',
+    example: 80,
+    nullable: true,
+  })
   diastolicBp: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Pulse rate in beats per minute',
+    example: 72,
+    nullable: true,
+  })
   pulseRate: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Respiratory rate in breaths per minute',
+    example: 16,
+    nullable: true,
+  })
   respiratoryRate: number | null;
+
+  @ApiPropertyOptional({ description: 'Oxygen saturation percentage', example: 98, nullable: true })
   oxygenSaturation: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Blood glucose level in mg/dL',
+    example: 100,
+    nullable: true,
+  })
   bloodGlucose: number | null;
+
+  @ApiPropertyOptional({ description: 'Pain score (0-10)', example: 3, nullable: true })
   painScore: number | null;
+
+  @ApiPropertyOptional({ description: 'Consciousness level', enum: Consciousness, nullable: true })
   consciousness: Consciousness | null;
+
+  @ApiProperty({ description: 'Time when vitals were measured' })
   measuredAt: Date;
+
+  @ApiProperty({
+    description: 'User ID who recorded the vitals',
+    example: '550e8400-e29b-41d4-a716-446655440002',
+  })
   measuredBy: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'Whether any vital signs are outside normal range', example: false })
   hasAlert: boolean;
+
+  @ApiPropertyOptional({ description: 'List of alerts for abnormal values', type: 'array' })
   alerts?: VitalAlert[];
+
+  @ApiProperty({ description: 'Record creation timestamp' })
   createdAt: Date;
 }
 
@@ -28,10 +92,19 @@ export class VitalSignResponseDto {
  * Paginated response for vital sign history
  */
 export class PaginatedVitalSignsResponseDto {
+  @ApiProperty({ description: 'Array of vital sign records', type: [VitalSignResponseDto] })
   data: VitalSignResponseDto[];
+
+  @ApiProperty({ description: 'Total number of records', example: 100 })
   total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 5 })
   totalPages: number;
 }
 
@@ -39,11 +112,32 @@ export class PaginatedVitalSignsResponseDto {
  * Response DTO for vital signs trend data (REQ-FR-032)
  */
 export class VitalTrendResponseDto {
+  @ApiProperty({ description: 'Array of measurement timestamps', type: [Date] })
   labels: Date[];
+
+  @ApiProperty({ description: 'Temperature values array', type: [Number], nullable: true })
   temperature: (number | null)[];
+
+  @ApiProperty({
+    description: 'Systolic blood pressure values array',
+    type: [Number],
+    nullable: true,
+  })
   systolicBp: (number | null)[];
+
+  @ApiProperty({
+    description: 'Diastolic blood pressure values array',
+    type: [Number],
+    nullable: true,
+  })
   diastolicBp: (number | null)[];
+
+  @ApiProperty({ description: 'Pulse rate values array', type: [Number], nullable: true })
   pulseRate: (number | null)[];
+
+  @ApiProperty({ description: 'Respiratory rate values array', type: [Number], nullable: true })
   respiratoryRate: (number | null)[];
+
+  @ApiProperty({ description: 'Oxygen saturation values array', type: [Number], nullable: true })
   oxygenSaturation: (number | null)[];
 }

--- a/apps/backend/src/modules/report/intake-output.controller.ts
+++ b/apps/backend/src/modules/report/intake-output.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { IntakeOutputService } from './intake-output.service';
 import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
@@ -18,6 +19,8 @@ import { GetIOHistoryDto, GetIOBalanceDto } from './dto/get-io-history.dto';
  * Reference: SDS Section 4.5 (Report Module)
  * Requirements: REQ-FR-036~038
  */
+@ApiTags('intake-output')
+@ApiBearerAuth()
 @Controller('admissions/:admissionId/io')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class IntakeOutputController {
@@ -27,6 +30,17 @@ export class IntakeOutputController {
    * Record intake/output (REQ-FR-036)
    * POST /admissions/:admissionId/io
    */
+  @ApiOperation({ summary: 'Record intake/output for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Intake/output recorded successfully',
+    type: IntakeOutputResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Post()
   @RequirePermission('report:write')
   async record(
@@ -42,6 +56,16 @@ export class IntakeOutputController {
    * Get intake/output history
    * GET /admissions/:admissionId/io
    */
+  @ApiOperation({ summary: 'Get intake/output history for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Intake/output history retrieved',
+    type: PaginatedIOResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get()
   @RequirePermission('report:read')
   async getHistory(
@@ -55,6 +79,13 @@ export class IntakeOutputController {
    * Get daily I/O summary (REQ-FR-037)
    * GET /admissions/:admissionId/io/daily/:date
    */
+  @ApiOperation({ summary: 'Get daily intake/output summary for a specific date' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'date', description: 'Date in YYYY-MM-DD format' })
+  @ApiResponse({ status: 200, description: 'Daily I/O summary retrieved', type: IODailySummaryDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('daily/:date')
   @RequirePermission('report:read')
   async getDailySummary(
@@ -69,6 +100,12 @@ export class IntakeOutputController {
    * Get I/O balance history (REQ-FR-038)
    * GET /admissions/:admissionId/io/balance
    */
+  @ApiOperation({ summary: 'Get intake/output balance history for a date range' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({ status: 200, description: 'I/O balance history retrieved', type: [IOBalanceDto] })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('balance')
   @RequirePermission('report:read')
   async getBalanceHistory(

--- a/apps/backend/src/modules/report/medication.controller.ts
+++ b/apps/backend/src/modules/report/medication.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { MedicationService } from './medication.service';
 import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
@@ -19,6 +20,8 @@ import {
  * Reference: SDS Section 4.5 (Report Module)
  * Requirements: REQ-FR-036~038
  */
+@ApiTags('medications')
+@ApiBearerAuth()
 @Controller('admissions/:admissionId/medications')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class MedicationController {
@@ -28,6 +31,17 @@ export class MedicationController {
    * Schedule medication
    * POST /admissions/:admissionId/medications
    */
+  @ApiOperation({ summary: 'Schedule a medication for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Medication scheduled successfully',
+    type: MedicationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Post()
   @RequirePermission('report:write')
   async schedule(
@@ -41,6 +55,18 @@ export class MedicationController {
    * Administer medication
    * POST /admissions/:admissionId/medications/:id/administer
    */
+  @ApiOperation({ summary: 'Administer a scheduled medication' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Medication UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medication administered successfully',
+    type: MedicationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Medication not found' })
   @Post(':id/administer')
   @RequirePermission('report:write')
   async administer(
@@ -56,6 +82,18 @@ export class MedicationController {
    * Hold medication
    * POST /admissions/:admissionId/medications/:id/hold
    */
+  @ApiOperation({ summary: 'Hold a scheduled medication' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Medication UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medication held successfully',
+    type: MedicationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Medication not found' })
   @Post(':id/hold')
   @RequirePermission('report:write')
   async hold(
@@ -71,6 +109,18 @@ export class MedicationController {
    * Refuse medication
    * POST /admissions/:admissionId/medications/:id/refuse
    */
+  @ApiOperation({ summary: 'Record patient refusal of medication' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Medication UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medication refusal recorded',
+    type: MedicationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Medication not found' })
   @Post(':id/refuse')
   @RequirePermission('report:write')
   async refuse(
@@ -86,6 +136,17 @@ export class MedicationController {
    * Get scheduled medications for a date
    * GET /admissions/:admissionId/medications/scheduled/:date
    */
+  @ApiOperation({ summary: 'Get scheduled medications for a specific date' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'date', description: 'Date in YYYY-MM-DD format' })
+  @ApiResponse({
+    status: 200,
+    description: 'Scheduled medications retrieved',
+    type: [MedicationResponseDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('scheduled/:date')
   @RequirePermission('report:read')
   async getScheduled(
@@ -100,6 +161,16 @@ export class MedicationController {
    * Get medication history
    * GET /admissions/:admissionId/medications
    */
+  @ApiOperation({ summary: 'Get medication history for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medication history retrieved',
+    type: PaginatedMedicationResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get()
   @RequirePermission('report:read')
   async getHistory(

--- a/apps/backend/src/modules/report/nursing-note.controller.ts
+++ b/apps/backend/src/modules/report/nursing-note.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { NursingNoteService } from './nursing-note.service';
 import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
@@ -16,6 +17,8 @@ import {
  * Reference: SDS Section 4.5 (Report Module)
  * Requirements: REQ-FR-036~038
  */
+@ApiTags('nursing-notes')
+@ApiBearerAuth()
 @Controller('admissions/:admissionId/notes')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class NursingNoteController {
@@ -25,6 +28,17 @@ export class NursingNoteController {
    * Create nursing note
    * POST /admissions/:admissionId/notes
    */
+  @ApiOperation({ summary: 'Create a nursing note for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Nursing note created successfully',
+    type: NursingNoteResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Post()
   @RequirePermission('report:write')
   async create(
@@ -40,6 +54,16 @@ export class NursingNoteController {
    * Get nursing notes
    * GET /admissions/:admissionId/notes
    */
+  @ApiOperation({ summary: 'Get nursing notes for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Nursing notes retrieved',
+    type: PaginatedNursingNotesResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get()
   @RequirePermission('report:read')
   async list(
@@ -53,6 +77,16 @@ export class NursingNoteController {
    * Get significant nursing notes
    * GET /admissions/:admissionId/notes/significant
    */
+  @ApiOperation({ summary: 'Get significant nursing notes for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Significant nursing notes retrieved',
+    type: [NursingNoteResponseDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('significant')
   @RequirePermission('report:read')
   async getSignificant(
@@ -65,6 +99,16 @@ export class NursingNoteController {
    * Get latest nursing note
    * GET /admissions/:admissionId/notes/latest
    */
+  @ApiOperation({ summary: 'Get the latest nursing note for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Latest nursing note retrieved',
+    type: NursingNoteResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('latest')
   @RequirePermission('report:read')
   async getLatest(

--- a/apps/backend/src/modules/report/vital-sign.controller.ts
+++ b/apps/backend/src/modules/report/vital-sign.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { VitalSignService } from './vital-sign.service';
 import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
@@ -18,6 +19,8 @@ import {
  * Reference: SDS Section 4.5 (Report Module)
  * Requirements: REQ-FR-030~035
  */
+@ApiTags('vitals')
+@ApiBearerAuth()
 @Controller('admissions/:admissionId/vitals')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class VitalSignController {
@@ -27,6 +30,17 @@ export class VitalSignController {
    * Record vital signs (REQ-FR-030)
    * POST /admissions/:admissionId/vitals
    */
+  @ApiOperation({ summary: 'Record vital signs for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Vital signs recorded successfully',
+    type: VitalSignResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Post()
   @RequirePermission('vital:write')
   async record(
@@ -42,6 +56,16 @@ export class VitalSignController {
    * Get vital signs history (REQ-FR-031)
    * GET /admissions/:admissionId/vitals
    */
+  @ApiOperation({ summary: 'Get vital signs history for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Vital signs history retrieved',
+    type: PaginatedVitalSignsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get()
   @RequirePermission('vital:read')
   async getHistory(
@@ -55,6 +79,16 @@ export class VitalSignController {
    * Get latest vital signs
    * GET /admissions/:admissionId/vitals/latest
    */
+  @ApiOperation({ summary: 'Get latest vital signs for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Latest vital signs retrieved',
+    type: VitalSignResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('latest')
   @RequirePermission('vital:read')
   async getLatest(
@@ -67,6 +101,16 @@ export class VitalSignController {
    * Get vital signs trend data (REQ-FR-032)
    * GET /admissions/:admissionId/vitals/trend
    */
+  @ApiOperation({ summary: 'Get vital signs trend data for an admission' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Vital signs trend data retrieved',
+    type: VitalTrendResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
   @Get('trend')
   @RequirePermission('vital:read')
   async getTrend(

--- a/apps/backend/src/modules/room/dto/dashboard.dto.ts
+++ b/apps/backend/src/modules/room/dto/dashboard.dto.ts
@@ -1,50 +1,118 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RoomType, BedStatus } from '@prisma/client';
 
 export class DashboardSummary {
+  @ApiProperty({ description: 'Total beds' })
   totalBeds: number;
+
+  @ApiProperty({ description: 'Occupied beds' })
   occupiedBeds: number;
+
+  @ApiProperty({ description: 'Empty beds' })
   emptyBeds: number;
+
+  @ApiProperty({ description: 'Reserved beds' })
   reservedBeds: number;
+
+  @ApiProperty({ description: 'Beds under maintenance' })
   maintenanceBeds: number;
 }
 
-export class DashboardBed {
+export class DashboardPatient {
+  @ApiProperty({ description: 'Patient ID' })
   id: string;
+
+  @ApiProperty({ description: 'Patient name' })
+  name: string;
+
+  @ApiProperty({ description: 'Admission date' })
+  admissionDate: Date;
+}
+
+export class DashboardBed {
+  @ApiProperty({ description: 'Bed ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Bed number' })
   bedNumber: string;
+
+  @ApiProperty({
+    description: 'Bed status',
+    enum: ['EMPTY', 'OCCUPIED', 'RESERVED', 'MAINTENANCE'],
+  })
   status: BedStatus;
-  patient: {
-    id: string;
-    name: string;
-    admissionDate: Date;
-  } | null;
+
+  @ApiPropertyOptional({ description: 'Patient info', type: DashboardPatient, nullable: true })
+  patient: DashboardPatient | null;
 }
 
 export class DashboardRoom {
+  @ApiProperty({ description: 'Room ID' })
   id: string;
+
+  @ApiProperty({ description: 'Room number' })
   roomNumber: string;
+
+  @ApiProperty({
+    description: 'Room type',
+    enum: ['GENERAL', 'ICU', 'ISOLATION', 'PRIVATE', 'SEMI_PRIVATE'],
+  })
   roomType: RoomType;
+
+  @ApiProperty({ description: 'Beds in room', type: [DashboardBed] })
   beds: DashboardBed[];
 }
 
 export class FloorDashboard {
+  @ApiProperty({ description: 'Floor ID' })
   floorId: string;
+
+  @ApiProperty({ description: 'Floor number' })
   floorNumber: number;
+
+  @ApiProperty({ description: 'Floor name' })
   name: string;
+
+  @ApiPropertyOptional({ description: 'Department', nullable: true })
   department: string | null;
+
+  @ApiProperty({ description: 'Summary statistics', type: DashboardSummary })
   summary: DashboardSummary;
+
+  @ApiProperty({ description: 'Rooms on floor', type: [DashboardRoom] })
   rooms: DashboardRoom[];
 }
 
-export class BuildingDashboard {
-  buildingId: string;
-  code: string;
+export class FloorSummaryDto {
+  @ApiProperty({ description: 'Floor ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Floor number' })
+  floorNumber: number;
+
+  @ApiProperty({ description: 'Floor name' })
   name: string;
+
+  @ApiPropertyOptional({ description: 'Department', nullable: true })
+  department: string | null;
+
+  @ApiProperty({ description: 'Summary statistics', type: DashboardSummary })
   summary: DashboardSummary;
-  floors: {
-    id: string;
-    floorNumber: number;
-    name: string;
-    department: string | null;
-    summary: DashboardSummary;
-  }[];
+}
+
+export class BuildingDashboard {
+  @ApiProperty({ description: 'Building ID' })
+  buildingId: string;
+
+  @ApiProperty({ description: 'Building code' })
+  code: string;
+
+  @ApiProperty({ description: 'Building name' })
+  name: string;
+
+  @ApiProperty({ description: 'Summary statistics', type: DashboardSummary })
+  summary: DashboardSummary;
+
+  @ApiProperty({ description: 'Floors summary', type: [FloorSummaryDto] })
+  floors: FloorSummaryDto[];
 }

--- a/apps/backend/src/modules/room/dto/find-available-beds.dto.ts
+++ b/apps/backend/src/modules/room/dto/find-available-beds.dto.ts
@@ -1,30 +1,43 @@
 import { IsOptional, IsString, IsEnum, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { RoomType, BedStatus } from '@prisma/client';
 
 export class FindAvailableBedsDto {
+  @ApiPropertyOptional({ description: 'Filter by building ID' })
   @IsOptional()
   @IsString()
   buildingId?: string;
 
+  @ApiPropertyOptional({ description: 'Filter by floor ID' })
   @IsOptional()
   @IsString()
   floorId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by room type',
+    enum: ['GENERAL', 'ICU', 'ISOLATION', 'PRIVATE', 'SEMI_PRIVATE'],
+  })
   @IsOptional()
   @IsEnum(RoomType)
   roomType?: RoomType;
 
+  @ApiPropertyOptional({
+    description: 'Filter by bed status',
+    enum: ['EMPTY', 'OCCUPIED', 'RESERVED', 'MAINTENANCE'],
+  })
   @IsOptional()
   @IsEnum(BedStatus)
   status?: BedStatus;
 
+  @ApiPropertyOptional({ description: 'Page number', default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({ description: 'Items per page', default: 20, minimum: 1, maximum: 100 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/apps/backend/src/modules/room/dto/room-response.dto.ts
+++ b/apps/backend/src/modules/room/dto/room-response.dto.ts
@@ -1,39 +1,94 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RoomType, BedStatus } from '@prisma/client';
 
 export class BedResponseDto {
+  @ApiProperty({ description: 'Bed ID' })
   id: string;
+
+  @ApiProperty({ description: 'Bed number', example: 'A' })
   bedNumber: string;
+
+  @ApiProperty({
+    description: 'Bed status',
+    enum: ['EMPTY', 'OCCUPIED', 'RESERVED', 'MAINTENANCE'],
+  })
   status: BedStatus;
+
+  @ApiPropertyOptional({ description: 'Current admission ID', nullable: true })
   currentAdmissionId: string | null;
+
+  @ApiPropertyOptional({ description: 'Notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'Is bed active' })
   isActive: boolean;
 }
 
 export class RoomResponseDto {
+  @ApiProperty({ description: 'Room ID' })
   id: string;
+
+  @ApiProperty({ description: 'Room number', example: '301' })
   roomNumber: string;
+
+  @ApiPropertyOptional({ description: 'Room name', nullable: true })
   name: string | null;
+
+  @ApiProperty({
+    description: 'Room type',
+    enum: ['GENERAL', 'ICU', 'ISOLATION', 'PRIVATE', 'SEMI_PRIVATE'],
+  })
   roomType: RoomType;
+
+  @ApiProperty({ description: 'Number of beds in room' })
   bedCount: number;
+
+  @ApiProperty({ description: 'Is room active' })
   isActive: boolean;
+
+  @ApiPropertyOptional({ description: 'Notes', nullable: true })
   notes: string | null;
+
+  @ApiProperty({ description: 'Beds in room', type: [BedResponseDto] })
   beds: BedResponseDto[];
 }
 
 export class FloorResponseDto {
+  @ApiProperty({ description: 'Floor ID' })
   id: string;
+
+  @ApiProperty({ description: 'Floor number', example: 3 })
   floorNumber: number;
+
+  @ApiProperty({ description: 'Floor name', example: '3F - Internal Medicine' })
   name: string;
+
+  @ApiPropertyOptional({ description: 'Department', nullable: true })
   department: string | null;
+
+  @ApiProperty({ description: 'Is floor active' })
   isActive: boolean;
+
+  @ApiPropertyOptional({ description: 'Rooms on floor', type: [RoomResponseDto] })
   rooms?: RoomResponseDto[];
 }
 
 export class BuildingResponseDto {
+  @ApiProperty({ description: 'Building ID' })
   id: string;
+
+  @ApiProperty({ description: 'Building code', example: 'MAIN' })
   code: string;
+
+  @ApiProperty({ description: 'Building name', example: 'Main Building' })
   name: string;
+
+  @ApiPropertyOptional({ description: 'Address', nullable: true })
   address: string | null;
+
+  @ApiProperty({ description: 'Is building active' })
   isActive: boolean;
+
+  @ApiPropertyOptional({ description: 'Floors in building', type: [FloorResponseDto] })
   floors?: FloorResponseDto[];
 }

--- a/apps/backend/src/modules/room/dto/update-bed-status.dto.ts
+++ b/apps/backend/src/modules/room/dto/update-bed-status.dto.ts
@@ -1,14 +1,21 @@
 import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { BedStatus } from '@prisma/client';
 
 export class UpdateBedStatusDto {
+  @ApiProperty({
+    description: 'Bed status',
+    enum: ['EMPTY', 'OCCUPIED', 'RESERVED', 'MAINTENANCE'],
+  })
   @IsEnum(BedStatus)
   status: BedStatus;
 
+  @ApiPropertyOptional({ description: 'Current admission ID' })
   @IsOptional()
   @IsUUID('4')
   currentAdmissionId?: string;
 
+  @ApiPropertyOptional({ description: 'Additional notes' })
   @IsOptional()
   @IsString()
   notes?: string;

--- a/apps/backend/src/modules/room/room.controller.ts
+++ b/apps/backend/src/modules/room/room.controller.ts
@@ -1,9 +1,20 @@
 import { Controller, Get, Patch, Post, Param, Query, Body, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
 import { RoomService } from './room.service';
 import { BedService } from './bed.service';
 import { RoomDashboardService } from './room-dashboard.service';
-import { FindAvailableBedsDto, UpdateBedStatusDto } from './dto';
+import {
+  FindAvailableBedsDto,
+  UpdateBedStatusDto,
+  BuildingResponseDto,
+  FloorResponseDto,
+  RoomResponseDto,
+  BedResponseDto,
+  BuildingDashboard,
+  FloorDashboard,
+} from './dto';
 
+@ApiTags('rooms')
 @Controller('rooms')
 export class RoomController {
   constructor(
@@ -12,46 +23,75 @@ export class RoomController {
     private readonly roomDashboardService: RoomDashboardService,
   ) {}
 
+  @ApiOperation({ summary: 'Get all buildings' })
+  @ApiResponse({ status: 200, description: 'Building list', type: [BuildingResponseDto] })
   @Get('buildings')
   async getAllBuildings() {
     return this.roomService.findAllBuildings();
   }
 
+  @ApiOperation({ summary: 'Get building by ID' })
+  @ApiParam({ name: 'id', description: 'Building ID' })
+  @ApiResponse({ status: 200, description: 'Building found', type: BuildingResponseDto })
+  @ApiResponse({ status: 404, description: 'Building not found' })
   @Get('buildings/:id')
   async getBuildingById(@Param('id', ParseUUIDPipe) id: string) {
     return this.roomService.findBuildingById(id);
   }
 
+  @ApiOperation({ summary: 'Get floors by building' })
+  @ApiParam({ name: 'buildingId', description: 'Building ID' })
+  @ApiResponse({ status: 200, description: 'Floor list', type: [FloorResponseDto] })
   @Get('buildings/:buildingId/floors')
   async getFloorsByBuilding(@Param('buildingId', ParseUUIDPipe) buildingId: string) {
     return this.roomService.findFloorsByBuilding(buildingId);
   }
 
+  @ApiOperation({ summary: 'Get rooms by floor' })
+  @ApiParam({ name: 'floorId', description: 'Floor ID' })
+  @ApiResponse({ status: 200, description: 'Room list', type: [RoomResponseDto] })
   @Get('floors/:floorId/rooms')
   async getRoomsByFloor(@Param('floorId', ParseUUIDPipe) floorId: string) {
     return this.roomService.findRoomsByFloor(floorId);
   }
 
+  @ApiOperation({ summary: 'Get room by ID' })
+  @ApiParam({ name: 'id', description: 'Room ID' })
+  @ApiResponse({ status: 200, description: 'Room found', type: RoomResponseDto })
+  @ApiResponse({ status: 404, description: 'Room not found' })
   @Get(':id')
   async getRoomById(@Param('id', ParseUUIDPipe) id: string) {
     return this.roomService.findRoomById(id);
   }
 
+  @ApiOperation({ summary: 'Get available beds' })
+  @ApiResponse({ status: 200, description: 'Available beds', type: [BedResponseDto] })
   @Get('beds/available')
   async getAvailableBeds(@Query() query: FindAvailableBedsDto) {
     return this.bedService.findAvailable(query);
   }
 
+  @ApiOperation({ summary: 'Get bed by ID' })
+  @ApiParam({ name: 'id', description: 'Bed ID' })
+  @ApiResponse({ status: 200, description: 'Bed found', type: BedResponseDto })
+  @ApiResponse({ status: 404, description: 'Bed not found' })
   @Get('beds/:id')
   async getBedById(@Param('id', ParseUUIDPipe) id: string) {
     return this.bedService.findById(id);
   }
 
+  @ApiOperation({ summary: 'Update bed status' })
+  @ApiParam({ name: 'id', description: 'Bed ID' })
+  @ApiResponse({ status: 200, description: 'Bed status updated', type: BedResponseDto })
   @Patch('beds/:id/status')
   async updateBedStatus(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateBedStatusDto) {
     return this.bedService.updateStatus(id, dto);
   }
 
+  @ApiOperation({ summary: 'Occupy bed with admission' })
+  @ApiParam({ name: 'id', description: 'Bed ID' })
+  @ApiBody({ schema: { properties: { admissionId: { type: 'string', format: 'uuid' } } } })
+  @ApiResponse({ status: 200, description: 'Bed occupied', type: BedResponseDto })
   @Post('beds/:id/occupy')
   async occupyBed(
     @Param('id', ParseUUIDPipe) id: string,
@@ -60,31 +100,49 @@ export class RoomController {
     return this.bedService.occupy(id, admissionId);
   }
 
+  @ApiOperation({ summary: 'Release bed' })
+  @ApiParam({ name: 'id', description: 'Bed ID' })
+  @ApiResponse({ status: 200, description: 'Bed released', type: BedResponseDto })
   @Post('beds/:id/release')
   async releaseBed(@Param('id', ParseUUIDPipe) id: string) {
     return this.bedService.release(id);
   }
 
+  @ApiOperation({ summary: 'Reserve bed' })
+  @ApiParam({ name: 'id', description: 'Bed ID' })
+  @ApiResponse({ status: 200, description: 'Bed reserved', type: BedResponseDto })
   @Post('beds/:id/reserve')
   async reserveBed(@Param('id', ParseUUIDPipe) id: string) {
     return this.bedService.reserve(id);
   }
 
+  @ApiOperation({ summary: 'Set bed to maintenance' })
+  @ApiParam({ name: 'id', description: 'Bed ID' })
+  @ApiBody({ schema: { properties: { notes: { type: 'string' } } } })
+  @ApiResponse({ status: 200, description: 'Bed set to maintenance', type: BedResponseDto })
   @Post('beds/:id/maintenance')
   async setMaintenance(@Param('id', ParseUUIDPipe) id: string, @Body('notes') notes?: string) {
     return this.bedService.setMaintenance(id, notes);
   }
 
+  @ApiOperation({ summary: 'Get all buildings dashboard' })
+  @ApiResponse({ status: 200, description: 'Buildings dashboard', type: [BuildingDashboard] })
   @Get('dashboard/buildings')
   async getAllBuildingsDashboard() {
     return this.roomDashboardService.getAllBuildingsDashboard();
   }
 
+  @ApiOperation({ summary: 'Get building dashboard' })
+  @ApiParam({ name: 'buildingId', description: 'Building ID' })
+  @ApiResponse({ status: 200, description: 'Building dashboard', type: BuildingDashboard })
   @Get('dashboard/building/:buildingId')
   async getBuildingDashboard(@Param('buildingId', ParseUUIDPipe) buildingId: string) {
     return this.roomDashboardService.getBuildingDashboard(buildingId);
   }
 
+  @ApiOperation({ summary: 'Get floor dashboard' })
+  @ApiParam({ name: 'floorId', description: 'Floor ID' })
+  @ApiResponse({ status: 200, description: 'Floor dashboard', type: FloorDashboard })
   @Get('dashboard/floor/:floorId')
   async getFloorDashboard(@Param('floorId', ParseUUIDPipe) floorId: string) {
     return this.roomDashboardService.getFloorDashboard(floorId);

--- a/apps/backend/src/modules/rounding/dto/create-round-record.dto.ts
+++ b/apps/backend/src/modules/rounding/dto/create-round-record.dto.ts
@@ -1,35 +1,70 @@
 import { IsNotEmpty, IsString, IsEnum, IsOptional, IsUUID, MaxLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RoundPatientStatus } from '@prisma/client';
 
 export class CreateRoundRecordDto {
+  @ApiProperty({
+    description: 'Admission ID for the patient record',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsNotEmpty()
   @IsUUID()
   admissionId: string;
 
+  @ApiPropertyOptional({
+    description: 'Patient status during round',
+    enum: RoundPatientStatus,
+    example: 'STABLE',
+  })
   @IsOptional()
   @IsEnum(RoundPatientStatus)
   patientStatus?: RoundPatientStatus;
 
+  @ApiPropertyOptional({
+    description: 'Chief complaint from patient',
+    example: 'Persistent headache since yesterday',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   chiefComplaint?: string;
 
+  @ApiPropertyOptional({
+    description: 'Clinical observation notes',
+    example: 'Patient appears alert and oriented',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   observation?: string;
 
+  @ApiPropertyOptional({
+    description: 'Clinical assessment',
+    example: 'Condition improving, vitals stable',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   assessment?: string;
 
+  @ApiPropertyOptional({
+    description: 'Treatment plan',
+    example: 'Continue current medication, follow up in 24 hours',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   plan?: string;
 
+  @ApiPropertyOptional({
+    description: 'Medical orders',
+    example: 'CBC, BMP in AM; PT eval today',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)

--- a/apps/backend/src/modules/rounding/dto/create-round.dto.ts
+++ b/apps/backend/src/modules/rounding/dto/create-round.dto.ts
@@ -8,21 +8,29 @@ import {
   Matches,
   MaxLength,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RoundType } from '@prisma/client';
 
 export class CreateRoundDto {
+  @ApiProperty({
+    description: 'Floor ID for the round',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsNotEmpty()
   @IsUUID()
   floorId: string;
 
+  @ApiProperty({ description: 'Type of round', enum: RoundType, example: 'MORNING' })
   @IsNotEmpty()
   @IsEnum(RoundType)
   roundType: RoundType;
 
+  @ApiProperty({ description: 'Scheduled date for the round (ISO 8601)', example: '2024-01-15' })
   @IsNotEmpty()
   @IsDateString()
   scheduledDate: string;
 
+  @ApiPropertyOptional({ description: 'Scheduled time in HH:mm format', example: '09:00' })
   @IsOptional()
   @IsString()
   @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/, {
@@ -30,10 +38,19 @@ export class CreateRoundDto {
   })
   scheduledTime?: string;
 
+  @ApiProperty({
+    description: 'Lead doctor ID for the round',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  })
   @IsNotEmpty()
   @IsUUID()
   leadDoctorId: string;
 
+  @ApiPropertyOptional({
+    description: 'Additional notes for the round',
+    example: 'Focus on post-op patients',
+    maxLength: 1000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(1000)

--- a/apps/backend/src/modules/rounding/dto/find-rounds.dto.ts
+++ b/apps/backend/src/modules/rounding/dto/find-rounds.dto.ts
@@ -1,38 +1,69 @@
 import { IsOptional, IsEnum, IsDateString, IsUUID, IsInt, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { RoundStatus, RoundType } from '@prisma/client';
 
 export class FindRoundsDto {
+  @ApiPropertyOptional({
+    description: 'Filter by floor ID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsOptional()
   @IsUUID()
   floorId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by lead doctor ID',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  })
   @IsOptional()
   @IsUUID()
   leadDoctorId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by round status',
+    enum: RoundStatus,
+    example: 'SCHEDULED',
+  })
   @IsOptional()
   @IsEnum(RoundStatus)
   status?: RoundStatus;
 
+  @ApiPropertyOptional({ description: 'Filter by round type', enum: RoundType, example: 'MORNING' })
   @IsOptional()
   @IsEnum(RoundType)
   roundType?: RoundType;
 
+  @ApiPropertyOptional({
+    description: 'Filter by scheduled date from (ISO 8601)',
+    example: '2024-01-01',
+  })
   @IsOptional()
   @IsDateString()
   scheduledDateFrom?: string;
 
+  @ApiPropertyOptional({
+    description: 'Filter by scheduled date to (ISO 8601)',
+    example: '2024-01-31',
+  })
   @IsOptional()
   @IsDateString()
   scheduledDateTo?: string;
 
+  @ApiPropertyOptional({ description: 'Page number', example: 1, default: 1, minimum: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({
+    description: 'Items per page',
+    example: 20,
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/apps/backend/src/modules/rounding/dto/round-response.dto.ts
+++ b/apps/backend/src/modules/rounding/dto/round-response.dto.ts
@@ -1,47 +1,186 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { RoundType, RoundStatus, RoundPatientStatus } from '@prisma/client';
 
 export class RoundRecordResponseDto {
+  @ApiProperty({ description: 'Record ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Round ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   roundId: string;
+
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440002' })
   admissionId: string;
+
+  @ApiProperty({ description: 'Order in which patient was visited', example: 1 })
   visitOrder: number;
+
+  @ApiPropertyOptional({
+    description: 'Patient status during round',
+    enum: RoundPatientStatus,
+    example: 'STABLE',
+    nullable: true,
+  })
   patientStatus: RoundPatientStatus | null;
+
+  @ApiPropertyOptional({
+    description: 'Chief complaint from patient',
+    example: 'Persistent headache',
+    nullable: true,
+  })
   chiefComplaint: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Clinical observation notes',
+    example: 'Patient appears alert',
+    nullable: true,
+  })
   observation: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Clinical assessment',
+    example: 'Condition improving',
+    nullable: true,
+  })
   assessment: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Treatment plan',
+    example: 'Continue current medication',
+    nullable: true,
+  })
   plan: string | null;
+
+  @ApiPropertyOptional({ description: 'Medical orders', example: 'CBC in AM', nullable: true })
   orders: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Time when patient was visited',
+    example: '2024-01-15T09:30:00Z',
+    nullable: true,
+  })
   visitedAt: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Duration of visit in seconds',
+    example: 300,
+    nullable: true,
+  })
   visitDuration: number | null;
+
+  @ApiProperty({
+    description: 'ID of user who recorded this',
+    example: '550e8400-e29b-41d4-a716-446655440003',
+  })
   recordedBy: string;
+
+  @ApiProperty({ description: 'Record creation timestamp', example: '2024-01-15T09:00:00Z' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Record last update timestamp', example: '2024-01-15T09:30:00Z' })
   updatedAt: Date;
 }
 
 export class RoundResponseDto {
+  @ApiProperty({ description: 'Round ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   id: string;
+
+  @ApiProperty({ description: 'Round number', example: 'RND-20240115-001' })
   roundNumber: string;
+
+  @ApiProperty({ description: 'Floor ID', example: '550e8400-e29b-41d4-a716-446655440001' })
   floorId: string;
+
+  @ApiProperty({ description: 'Type of round', enum: RoundType, example: 'MORNING' })
   roundType: RoundType;
+
+  @ApiProperty({ description: 'Scheduled date for the round', example: '2024-01-15T00:00:00Z' })
   scheduledDate: Date;
+
+  @ApiPropertyOptional({
+    description: 'Scheduled time for the round',
+    example: '2024-01-15T09:00:00Z',
+    nullable: true,
+  })
   scheduledTime: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Time when round started',
+    example: '2024-01-15T09:05:00Z',
+    nullable: true,
+  })
   startedAt: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Time when round completed',
+    example: '2024-01-15T11:30:00Z',
+    nullable: true,
+  })
   completedAt: Date | null;
+
+  @ApiPropertyOptional({
+    description: 'Time when round was paused',
+    example: '2024-01-15T10:00:00Z',
+    nullable: true,
+  })
   pausedAt: Date | null;
+
+  @ApiProperty({
+    description: 'Current status of the round',
+    enum: RoundStatus,
+    example: 'SCHEDULED',
+  })
   status: RoundStatus;
+
+  @ApiProperty({ description: 'Lead doctor ID', example: '550e8400-e29b-41d4-a716-446655440002' })
   leadDoctorId: string;
+
+  @ApiPropertyOptional({
+    description: 'Additional notes',
+    example: 'Focus on post-op patients',
+    nullable: true,
+  })
   notes: string | null;
+
+  @ApiProperty({ description: 'Round creation timestamp', example: '2024-01-14T16:00:00Z' })
   createdAt: Date;
+
+  @ApiProperty({ description: 'Round last update timestamp', example: '2024-01-15T09:05:00Z' })
   updatedAt: Date;
+
+  @ApiProperty({
+    description: 'ID of user who created the round',
+    example: '550e8400-e29b-41d4-a716-446655440003',
+  })
   createdBy: string;
+
+  @ApiProperty({
+    description: 'List of patient records for this round',
+    type: [RoundRecordResponseDto],
+  })
   records: RoundRecordResponseDto[];
+
+  @ApiProperty({
+    description: 'Valid status transitions from current state',
+    enum: RoundStatus,
+    isArray: true,
+    example: ['IN_PROGRESS', 'CANCELLED'],
+  })
   validTransitions: RoundStatus[];
 }
 
 export class PaginatedRoundsResponseDto {
+  @ApiProperty({ description: 'List of rounds', type: [RoundResponseDto] })
   data: RoundResponseDto[];
+
+  @ApiProperty({ description: 'Total number of rounds matching the filter', example: 50 })
   total: number;
+
+  @ApiProperty({ description: 'Current page number', example: 1 })
   page: number;
+
+  @ApiProperty({ description: 'Items per page', example: 20 })
   limit: number;
+
+  @ApiProperty({ description: 'Total number of pages', example: 3 })
   totalPages: number;
 }

--- a/apps/backend/src/modules/rounding/dto/rounding-patient.dto.ts
+++ b/apps/backend/src/modules/rounding/dto/rounding-patient.dto.ts
@@ -1,52 +1,159 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Gender, AdmissionType, AdmissionStatus, Consciousness } from '@prisma/client';
 
-export interface LatestVitalsDto {
+export class LatestVitalsDto {
+  @ApiPropertyOptional({
+    description: 'Body temperature in Celsius',
+    example: 36.5,
+    nullable: true,
+  })
   temperature: number | null;
+
+  @ApiProperty({ description: 'Blood pressure reading', example: '120/80' })
   bloodPressure: string;
+
+  @ApiPropertyOptional({ description: 'Pulse rate in BPM', example: 72, nullable: true })
   pulseRate: number | null;
+
+  @ApiPropertyOptional({ description: 'Respiratory rate per minute', example: 16, nullable: true })
   respiratoryRate: number | null;
+
+  @ApiPropertyOptional({ description: 'Oxygen saturation percentage', example: 98, nullable: true })
   oxygenSaturation: number | null;
+
+  @ApiPropertyOptional({
+    description: 'Consciousness level',
+    enum: Consciousness,
+    example: 'ALERT',
+    nullable: true,
+  })
   consciousness: Consciousness | null;
+
+  @ApiProperty({ description: 'Time when vitals were measured', example: '2024-01-15T08:00:00Z' })
   measuredAt: Date;
+
+  @ApiProperty({ description: 'Whether any vital sign is outside normal range', example: false })
   hasAlert: boolean;
 }
 
-export interface RoundingPatientDto {
+export class PatientInfoDto {
+  @ApiProperty({ description: 'Patient ID', example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ description: 'Patient number', example: 'PT-2024-001234' })
+  patientNumber: string;
+
+  @ApiProperty({ description: 'Patient name', example: 'John Doe' })
+  name: string;
+
+  @ApiProperty({ description: 'Patient age in years', example: 45 })
+  age: number;
+
+  @ApiProperty({ description: 'Patient gender', enum: Gender, example: 'MALE' })
+  gender: Gender;
+
+  @ApiProperty({ description: 'Patient date of birth', example: '1979-05-15' })
+  birthDate: Date;
+}
+
+export class BedInfoDto {
+  @ApiProperty({ description: 'Bed ID', example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ description: 'Room number', example: '301' })
+  roomNumber: string;
+
+  @ApiProperty({ description: 'Bed number', example: 'A' })
+  bedNumber: string;
+
+  @ApiPropertyOptional({ description: 'Room name', example: 'Private Room 301', nullable: true })
+  roomName: string | null;
+}
+
+export class AdmissionInfoDto {
+  @ApiPropertyOptional({ description: 'Primary diagnosis', example: 'Pneumonia', nullable: true })
+  diagnosis: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Chief complaint at admission',
+    example: 'Difficulty breathing',
+    nullable: true,
+  })
+  chiefComplaint: string | null;
+
+  @ApiProperty({ description: 'Date of admission', example: '2024-01-10T14:30:00Z' })
+  admissionDate: Date;
+
+  @ApiProperty({ description: 'Number of days since admission', example: 5 })
+  admissionDays: number;
+
+  @ApiProperty({ description: 'Type of admission', enum: AdmissionType, example: 'EMERGENCY' })
+  admissionType: AdmissionType;
+
+  @ApiProperty({
+    description: 'Current admission status',
+    enum: AdmissionStatus,
+    example: 'ACTIVE',
+  })
+  status: AdmissionStatus;
+
+  @ApiProperty({
+    description: 'Attending doctor ID',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  })
+  attendingDoctorId: string;
+}
+
+export class RoundingPatientDto {
+  @ApiProperty({ description: 'Admission ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   admissionId: string;
-  patient: {
-    id: string;
-    patientNumber: string;
-    name: string;
-    age: number;
-    gender: Gender;
-    birthDate: Date;
-  };
-  bed: {
-    id: string;
-    roomNumber: string;
-    bedNumber: string;
-    roomName: string | null;
-  };
-  admission: {
-    diagnosis: string | null;
-    chiefComplaint: string | null;
-    admissionDate: Date;
-    admissionDays: number;
-    admissionType: AdmissionType;
-    status: AdmissionStatus;
-    attendingDoctorId: string;
-  };
+
+  @ApiProperty({ description: 'Patient information', type: PatientInfoDto })
+  patient: PatientInfoDto;
+
+  @ApiProperty({ description: 'Bed information', type: BedInfoDto })
+  bed: BedInfoDto;
+
+  @ApiProperty({ description: 'Admission information', type: AdmissionInfoDto })
+  admission: AdmissionInfoDto;
+
+  @ApiPropertyOptional({ description: 'Latest vital signs', type: LatestVitalsDto, nullable: true })
   latestVitals: LatestVitalsDto | null;
+
+  @ApiPropertyOptional({
+    description: 'Note from previous round',
+    example: 'Patient responding well to treatment',
+    nullable: true,
+  })
   previousRoundNote: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Existing record ID if patient already visited',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+    nullable: true,
+  })
   existingRecordId: string | null;
+
+  @ApiProperty({ description: 'Whether patient has been visited in this round', example: false })
   isVisited: boolean;
 }
 
 export class RoundingPatientListDto {
+  @ApiProperty({ description: 'Round ID', example: '550e8400-e29b-41d4-a716-446655440000' })
   roundId: string;
+
+  @ApiProperty({ description: 'Round number', example: 'RND-20240115-001' })
   roundNumber: string;
+
+  @ApiProperty({ description: 'List of patients for this round', type: [RoundingPatientDto] })
   patients: RoundingPatientDto[];
+
+  @ApiProperty({ description: 'Total number of patients in this round', example: 15 })
   totalPatients: number;
+
+  @ApiProperty({ description: 'Number of patients already visited', example: 5 })
   visitedCount: number;
+
+  @ApiProperty({ description: 'Progress percentage (0-100)', example: 33.33 })
   progress: number;
 }

--- a/apps/backend/src/modules/rounding/dto/update-round-record.dto.ts
+++ b/apps/backend/src/modules/rounding/dto/update-round-record.dto.ts
@@ -1,31 +1,62 @@
 import { IsString, IsEnum, IsOptional, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { RoundPatientStatus } from '@prisma/client';
 
 export class UpdateRoundRecordDto {
+  @ApiPropertyOptional({
+    description: 'Patient status during round',
+    enum: RoundPatientStatus,
+    example: 'STABLE',
+  })
   @IsOptional()
   @IsEnum(RoundPatientStatus)
   patientStatus?: RoundPatientStatus;
 
+  @ApiPropertyOptional({
+    description: 'Chief complaint from patient',
+    example: 'Persistent headache since yesterday',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   chiefComplaint?: string;
 
+  @ApiPropertyOptional({
+    description: 'Clinical observation notes',
+    example: 'Patient appears alert and oriented',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   observation?: string;
 
+  @ApiPropertyOptional({
+    description: 'Clinical assessment',
+    example: 'Condition improving, vitals stable',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   assessment?: string;
 
+  @ApiPropertyOptional({
+    description: 'Treatment plan',
+    example: 'Continue current medication, follow up in 24 hours',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)
   plan?: string;
 
+  @ApiPropertyOptional({
+    description: 'Medical orders',
+    example: 'CBC, BMP in AM; PT eval today',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2000)

--- a/apps/backend/src/modules/rounding/rounding.controller.ts
+++ b/apps/backend/src/modules/rounding/rounding.controller.ts
@@ -1,4 +1,12 @@
 import { Controller, Get, Post, Patch, Body, Param, Query, Headers } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiHeader,
+} from '@nestjs/swagger';
 import { RoundingService } from './rounding.service';
 import { TabletRoundingService } from './tablet-rounding.service';
 import { ParseUUIDPipe } from '../../common';
@@ -13,6 +21,8 @@ import {
   RoundingPatientListDto,
 } from './dto';
 
+@ApiTags('rounds')
+@ApiBearerAuth()
 @Controller('rounds')
 export class RoundController {
   constructor(
@@ -20,6 +30,11 @@ export class RoundController {
     private readonly tabletRoundingService: TabletRoundingService,
   ) {}
 
+  @ApiOperation({ summary: 'Create a new rounding session' })
+  @ApiHeader({ name: 'x-user-id', description: 'User ID creating the round', required: false })
+  @ApiResponse({ status: 201, description: 'Round created successfully', type: RoundResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post()
   async create(
     @Body() dto: CreateRoundDto,
@@ -29,56 +44,128 @@ export class RoundController {
     return this.roundingService.createSession(dto, effectiveUserId);
   }
 
+  @ApiOperation({ summary: 'Get all rounding sessions with filters' })
+  @ApiResponse({ status: 200, description: 'List of rounds', type: PaginatedRoundsResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Get()
   async findAll(@Query() dto: FindRoundsDto): Promise<PaginatedRoundsResponseDto> {
     return this.roundingService.findAll(dto);
   }
 
+  @ApiOperation({ summary: 'Get round by round number' })
+  @ApiParam({ name: 'roundNumber', description: 'Round number (e.g., RND-20240101-001)' })
+  @ApiResponse({ status: 200, description: 'Round details', type: RoundResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Get('by-number/:roundNumber')
   async findByRoundNumber(@Param('roundNumber') roundNumber: string): Promise<RoundResponseDto> {
     return this.roundingService.findByRoundNumber(roundNumber);
   }
 
+  @ApiOperation({ summary: 'Get round by ID' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({ status: 200, description: 'Round details', type: RoundResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Get(':id')
   async findById(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.findById(id);
   }
 
+  @ApiOperation({ summary: 'Start a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({ status: 200, description: 'Round started', type: RoundResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid state transition' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Post(':id/start')
   async start(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.startSession(id);
   }
 
+  @ApiOperation({ summary: 'Pause a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({ status: 200, description: 'Round paused', type: RoundResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid state transition' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Post(':id/pause')
   async pause(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.pauseSession(id);
   }
 
+  @ApiOperation({ summary: 'Resume a paused rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({ status: 200, description: 'Round resumed', type: RoundResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid state transition' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Post(':id/resume')
   async resume(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.resumeSession(id);
   }
 
+  @ApiOperation({ summary: 'Complete a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({ status: 200, description: 'Round completed', type: RoundResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid state transition' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Post(':id/complete')
   async complete(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.completeSession(id);
   }
 
+  @ApiOperation({ summary: 'Cancel a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({ status: 200, description: 'Round cancelled', type: RoundResponseDto })
+  @ApiResponse({ status: 400, description: 'Invalid state transition' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Post(':id/cancel')
   async cancel(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.cancelSession(id);
   }
 
+  @ApiOperation({ summary: 'Get patient list for a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Patient list for rounding',
+    type: RoundingPatientListDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Get(':id/patients')
   async getPatientList(@Param('id', ParseUUIDPipe) id: string): Promise<RoundingPatientListDto> {
     return this.tabletRoundingService.getRoundingPatientList(id);
   }
 
+  @ApiOperation({ summary: 'Get all records for a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of round records',
+    type: [RoundRecordResponseDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Get(':id/records')
   async getRecords(@Param('id', ParseUUIDPipe) id: string): Promise<RoundRecordResponseDto[]> {
     return this.roundingService.getRecordsByRound(id);
   }
 
+  @ApiOperation({ summary: 'Add a record to a rounding session' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiHeader({ name: 'x-user-id', description: 'User ID recording the round', required: false })
+  @ApiResponse({
+    status: 201,
+    description: 'Record added successfully',
+    type: RoundRecordResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round not found' })
   @Post(':id/records')
   async addRecord(
     @Param('id', ParseUUIDPipe) id: string,
@@ -89,6 +176,18 @@ export class RoundController {
     return this.tabletRoundingService.addRoundRecord(id, dto, effectiveUserId);
   }
 
+  @ApiOperation({ summary: 'Update a round record' })
+  @ApiParam({ name: 'id', description: 'Round UUID' })
+  @ApiParam({ name: 'recordId', description: 'Record UUID' })
+  @ApiHeader({ name: 'x-user-id', description: 'User ID updating the record', required: false })
+  @ApiResponse({
+    status: 200,
+    description: 'Record updated successfully',
+    type: RoundRecordResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Round or record not found' })
   @Patch(':id/records/:recordId')
   async updateRecord(
     @Param('id', ParseUUIDPipe) id: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@nestjs/schedule':
         specifier: ^6.1.0
         version: 6.1.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)
+      '@nestjs/swagger':
+        specifier: ^11.2.5
+        version: 11.2.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
       '@nestjs/websockets':
         specifier: ^10.4.22
         version: 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/platform-socket.io@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -119,6 +122,9 @@ importers:
       socket.io:
         specifier: ^4.8.3
         version: 4.8.3
+      swagger-ui-express:
+        specifier: ^5.0.1
+        version: 5.0.1(express@4.22.1)
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -1361,6 +1367,9 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
 
+  '@microsoft/tsdoc@0.16.0':
+    resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1485,6 +1494,23 @@ packages:
     resolution: {integrity: sha512-0NfPbPlEaGwIT8/TCThxLzrlz3yzDNkfRNpbL7FiplKq3w4qXpJg0JYwqgMEJnLQZm3L/L/5XjoyfJHUO3qX9g==}
     peerDependencies:
       typescript: '>=4.8.2'
+
+  '@nestjs/swagger@11.2.5':
+    resolution: {integrity: sha512-wCykbEybMqiYcvkyzPW4SbXKcwra9AGdajm0MvFgKR3W+gd1hfeKlo67g/s9QCRc/mqUU4KOE5Qtk7asMeFuiA==}
+    peerDependencies:
+      '@fastify/static': ^8.0.0 || ^9.0.0
+      '@nestjs/common': ^11.0.1
+      '@nestjs/core': ^11.0.1
+      class-transformer: '*'
+      class-validator: '*'
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      '@fastify/static':
+        optional: true
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@nestjs/terminus@10.2.0':
     resolution: {integrity: sha512-zPs98xvJ4ogEimRQOz8eU90mb7z+W/kd/mL4peOgrJ/VqER+ibN2Cboj65uJZW3XuNhpOqaeYOJte86InJd44A==}
@@ -2022,6 +2048,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -5018,6 +5047,9 @@ packages:
   path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -5728,6 +5760,15 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  swagger-ui-dist@5.31.0:
+    resolution: {integrity: sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
 
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
@@ -7785,6 +7826,8 @@ snapshots:
 
   '@lukeed/csprng@1.1.0': {}
 
+  '@microsoft/tsdoc@0.16.0': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -7963,6 +8006,21 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - chokidar
+
+  '@nestjs/swagger@11.2.5(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@microsoft/tsdoc': 0.16.0
+      '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@10.4.22)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.1.0(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)
+      js-yaml: 4.1.1
+      lodash: 4.17.21
+      path-to-regexp: 8.3.0
+      reflect-metadata: 0.2.2
+      swagger-ui-dist: 5.31.0
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.3
 
   '@nestjs/terminus@10.2.0(@nestjs/axios@3.1.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.13.2)(rxjs@7.8.2))(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@prisma/client@5.22.0(prisma@5.22.0))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
@@ -8401,6 +8459,8 @@ snapshots:
       rollup: 2.79.2
 
   '@rtsao/scc@1.1.0': {}
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -10081,7 +10141,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.1
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -10108,7 +10168,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10123,14 +10183,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10145,7 +10205,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11975,6 +12035,8 @@ snapshots:
 
   path-to-regexp@3.3.0: {}
 
+  path-to-regexp@8.3.0: {}
+
   path-type@4.0.0: {}
 
   pause@0.0.1: {}
@@ -12736,6 +12798,15 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swagger-ui-dist@5.31.0:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      swagger-ui-dist: 5.31.0
 
   symbol-observable@4.0.0: {}
 


### PR DESCRIPTION
## Summary

This PR implements comprehensive Swagger/OpenAPI documentation for all backend API endpoints, making the API self-documenting and easily explorable through the Swagger UI.

## What

- Installed and configured `@nestjs/swagger` package with DocumentBuilder
- Added Swagger UI accessible at `/api/docs` endpoint
- Documented all DTOs across all modules with `@ApiProperty` decorators
- Documented all controllers with `@ApiTags`, `@ApiOperation`, and `@ApiResponse` decorators
- Added `@ApiBearerAuth` for all authenticated endpoints
- Fixed `PartialType` imports to use `@nestjs/swagger` for proper schema inheritance

### Modules Documented

| Module | Controllers | DTOs |
|--------|------------|------|
| Auth | 1 | 4 |
| Patient | 1 | 6 |
| Room | 1 | 8 |
| Admission | 1 | 5 |
| Report (Vitals) | 1 | 4 |
| Report (I/O) | 1 | 4 |
| Report (Medication) | 1 | 3 |
| Report (Nursing Notes) | 1 | 3 |
| Report (Daily) | 1 | 8 |
| Rounding | 1 | 6 |
| Admin (Users) | 1 | 4 |
| Admin (Roles) | 1 | 2 |
| Admin (Audit) | 1 | 5 |

## Why

- Enables API consumers to understand and test endpoints without reading source code
- Provides interactive documentation for frontend developers and external integrations
- Improves developer experience with auto-generated OpenAPI specification
- Supports API versioning and client SDK generation

## Where

- `apps/backend/src/main.ts` - Swagger configuration
- `apps/backend/src/modules/*/dto/*.ts` - DTO decorators
- `apps/backend/src/modules/*/*.controller.ts` - Controller decorators

## Who

For all developers working with the Hospital ERP API:
- Frontend developers consuming the API
- QA engineers testing API endpoints
- External system integrators

## When

After merging, Swagger UI will be available at:
- Development: `http://localhost:4000/api/docs`
- Production: `https://<host>/api/docs`

## How

1. Navigate to `/api/docs` in your browser
2. Browse available endpoints grouped by tags
3. Click on any endpoint to see request/response schemas
4. Use "Try it out" to test endpoints directly

## Test Plan

- [x] Build succeeds without TypeScript errors
- [x] All 291 existing tests pass
- [ ] Swagger UI loads correctly at `/api/docs`
- [ ] All endpoints are visible and properly documented
- [ ] Request/response schemas are correctly generated

Closes #38