### PR TITLE
feat(frontend): add rounding module types, api client, and hooks

### DIFF
--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -10,3 +10,19 @@ export {
   useVitalTrend,
   useRecordVitalSign,
 } from './use-vital-signs';
+export {
+  roundingKeys,
+  useRounds,
+  useRound,
+  useRoundByNumber,
+  useRoundingPatients,
+  useRoundRecords,
+  useCreateRound,
+  useStartRound,
+  usePauseRound,
+  useResumeRound,
+  useCompleteRound,
+  useCancelRound,
+  useAddRoundRecord,
+  useUpdateRoundRecord,
+} from './use-rounding';

--- a/apps/frontend/src/hooks/use-rounding.ts
+++ b/apps/frontend/src/hooks/use-rounding.ts
@@ -1,0 +1,158 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { roundingApi } from '@/services';
+import type {
+  FindRoundsParams,
+  CreateRoundData,
+  CreateRoundRecordData,
+  UpdateRoundRecordData,
+} from '@/types';
+
+// Query keys
+export const roundingKeys = {
+  all: ['rounds'] as const,
+  lists: () => [...roundingKeys.all, 'list'] as const,
+  list: (params: FindRoundsParams) => [...roundingKeys.lists(), params] as const,
+  details: () => [...roundingKeys.all, 'detail'] as const,
+  detail: (id: string) => [...roundingKeys.details(), id] as const,
+  patients: (roundId: string) => [...roundingKeys.all, 'patients', roundId] as const,
+  records: (roundId: string) => [...roundingKeys.all, 'records', roundId] as const,
+};
+
+// Query hooks
+export function useRounds(params: FindRoundsParams = {}) {
+  return useQuery({
+    queryKey: roundingKeys.list(params),
+    queryFn: () => roundingApi.findAll(params),
+  });
+}
+
+export function useRound(id: string) {
+  return useQuery({
+    queryKey: roundingKeys.detail(id),
+    queryFn: () => roundingApi.findById(id),
+    enabled: !!id,
+  });
+}
+
+export function useRoundByNumber(roundNumber: string) {
+  return useQuery({
+    queryKey: ['rounds', 'by-number', roundNumber],
+    queryFn: () => roundingApi.findByRoundNumber(roundNumber),
+    enabled: !!roundNumber,
+  });
+}
+
+export function useRoundingPatients(roundId: string) {
+  return useQuery({
+    queryKey: roundingKeys.patients(roundId),
+    queryFn: () => roundingApi.getPatientList(roundId),
+    enabled: !!roundId,
+  });
+}
+
+export function useRoundRecords(roundId: string) {
+  return useQuery({
+    queryKey: roundingKeys.records(roundId),
+    queryFn: () => roundingApi.getRecords(roundId),
+    enabled: !!roundId,
+  });
+}
+
+// Mutation hooks
+export function useCreateRound() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateRoundData) => roundingApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.lists() });
+    },
+  });
+}
+
+export function useStartRound() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => roundingApi.start(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(data.id) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.lists() });
+    },
+  });
+}
+
+export function usePauseRound() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => roundingApi.pause(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(data.id) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.lists() });
+    },
+  });
+}
+
+export function useResumeRound() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => roundingApi.resume(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(data.id) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.lists() });
+    },
+  });
+}
+
+export function useCompleteRound() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => roundingApi.complete(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(data.id) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.lists() });
+    },
+  });
+}
+
+export function useCancelRound() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => roundingApi.cancel(id),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(data.id) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.lists() });
+    },
+  });
+}
+
+export function useAddRoundRecord(roundId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateRoundRecordData) => roundingApi.addRecord(roundId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(roundId) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.patients(roundId) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.records(roundId) });
+    },
+  });
+}
+
+export function useUpdateRoundRecord(roundId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ recordId, data }: { recordId: string; data: UpdateRoundRecordData }) =>
+      roundingApi.updateRecord(roundId, recordId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: roundingKeys.detail(roundId) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.patients(roundId) });
+      queryClient.invalidateQueries({ queryKey: roundingKeys.records(roundId) });
+    },
+  });
+}

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -3,3 +3,4 @@ export { admissionApi } from './admission-api';
 export { authApi } from './auth-api';
 export { roomApi } from './room-api';
 export { vitalApi } from './vital-api';
+export { roundingApi } from './rounding-api';

--- a/apps/frontend/src/services/rounding-api.ts
+++ b/apps/frontend/src/services/rounding-api.ts
@@ -1,0 +1,89 @@
+import { apiGet, apiPost, apiPatch } from '@/lib/api-client';
+import type {
+  Round,
+  RoundRecord,
+  PaginatedRounds,
+  FindRoundsParams,
+  CreateRoundData,
+  CreateRoundRecordData,
+  UpdateRoundRecordData,
+  RoundingPatientList,
+} from '@/types';
+
+function buildQueryString(params: FindRoundsParams): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.floorId) searchParams.set('floorId', params.floorId);
+  if (params.leadDoctorId) searchParams.set('leadDoctorId', params.leadDoctorId);
+  if (params.status) searchParams.set('status', params.status);
+  if (params.roundType) searchParams.set('roundType', params.roundType);
+  if (params.scheduledDateFrom) searchParams.set('scheduledDateFrom', params.scheduledDateFrom);
+  if (params.scheduledDateTo) searchParams.set('scheduledDateTo', params.scheduledDateTo);
+  if (params.page) searchParams.set('page', params.page.toString());
+  if (params.limit) searchParams.set('limit', params.limit.toString());
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export const roundingApi = {
+  // Round CRUD operations
+  create: (data: CreateRoundData): Promise<Round> => {
+    return apiPost<Round>('/rounds', data);
+  },
+
+  findAll: (params: FindRoundsParams = {}): Promise<PaginatedRounds> => {
+    return apiGet<PaginatedRounds>(`/rounds${buildQueryString(params)}`);
+  },
+
+  findById: (id: string): Promise<Round> => {
+    return apiGet<Round>(`/rounds/${id}`);
+  },
+
+  findByRoundNumber: (roundNumber: string): Promise<Round> => {
+    return apiGet<Round>(`/rounds/by-number/${roundNumber}`);
+  },
+
+  // Round state transitions
+  start: (id: string): Promise<Round> => {
+    return apiPost<Round>(`/rounds/${id}/start`);
+  },
+
+  pause: (id: string): Promise<Round> => {
+    return apiPost<Round>(`/rounds/${id}/pause`);
+  },
+
+  resume: (id: string): Promise<Round> => {
+    return apiPost<Round>(`/rounds/${id}/resume`);
+  },
+
+  complete: (id: string): Promise<Round> => {
+    return apiPost<Round>(`/rounds/${id}/complete`);
+  },
+
+  cancel: (id: string): Promise<Round> => {
+    return apiPost<Round>(`/rounds/${id}/cancel`);
+  },
+
+  // Patient list for rounding
+  getPatientList: (roundId: string): Promise<RoundingPatientList> => {
+    return apiGet<RoundingPatientList>(`/rounds/${roundId}/patients`);
+  },
+
+  // Round records
+  getRecords: (roundId: string): Promise<RoundRecord[]> => {
+    return apiGet<RoundRecord[]>(`/rounds/${roundId}/records`);
+  },
+
+  addRecord: (roundId: string, data: CreateRoundRecordData): Promise<RoundRecord> => {
+    return apiPost<RoundRecord>(`/rounds/${roundId}/records`, data);
+  },
+
+  updateRecord: (
+    roundId: string,
+    recordId: string,
+    data: UpdateRoundRecordData,
+  ): Promise<RoundRecord> => {
+    return apiPatch<RoundRecord>(`/rounds/${roundId}/records/${recordId}`, data);
+  },
+};

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -24,3 +24,4 @@ export * from './admission';
 export * from './auth';
 export * from './room';
 export * from './vital-sign';
+export * from './rounding';

--- a/apps/frontend/src/types/rounding.ts
+++ b/apps/frontend/src/types/rounding.ts
@@ -1,0 +1,154 @@
+// Rounding module type definitions
+
+import type { Gender } from './patient';
+import type { AdmissionType, AdmissionStatus } from './admission';
+import type { Consciousness } from './vital-sign';
+
+export type RoundType = 'MORNING' | 'AFTERNOON' | 'EVENING' | 'NIGHT';
+
+export type RoundStatus = 'PLANNED' | 'IN_PROGRESS' | 'PAUSED' | 'COMPLETED' | 'CANCELLED';
+
+export type RoundPatientStatus = 'STABLE' | 'IMPROVING' | 'DECLINING' | 'CRITICAL';
+
+export interface RoundRecord {
+  id: string;
+  roundId: string;
+  admissionId: string;
+  visitOrder: number;
+  patientStatus: RoundPatientStatus | null;
+  chiefComplaint: string | null;
+  observation: string | null;
+  assessment: string | null;
+  plan: string | null;
+  orders: string | null;
+  visitedAt: string | null;
+  visitDuration: number | null;
+  recordedBy: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Round {
+  id: string;
+  roundNumber: string;
+  floorId: string;
+  roundType: RoundType;
+  scheduledDate: string;
+  scheduledTime: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  pausedAt: string | null;
+  status: RoundStatus;
+  leadDoctorId: string;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+  records: RoundRecord[];
+  validTransitions: RoundStatus[];
+}
+
+export interface PaginatedRounds {
+  data: Round[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface FindRoundsParams {
+  floorId?: string;
+  leadDoctorId?: string;
+  status?: RoundStatus;
+  roundType?: RoundType;
+  scheduledDateFrom?: string;
+  scheduledDateTo?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface CreateRoundData {
+  floorId: string;
+  roundType: RoundType;
+  scheduledDate: string;
+  scheduledTime?: string;
+  leadDoctorId: string;
+  notes?: string;
+}
+
+export interface CreateRoundRecordData {
+  admissionId: string;
+  patientStatus?: RoundPatientStatus;
+  chiefComplaint?: string;
+  observation?: string;
+  assessment?: string;
+  plan?: string;
+  orders?: string;
+}
+
+export interface UpdateRoundRecordData {
+  patientStatus?: RoundPatientStatus;
+  chiefComplaint?: string;
+  observation?: string;
+  assessment?: string;
+  plan?: string;
+  orders?: string;
+}
+
+// Rounding patient list types
+export interface LatestVitals {
+  temperature: number | null;
+  bloodPressure: string;
+  pulseRate: number | null;
+  respiratoryRate: number | null;
+  oxygenSaturation: number | null;
+  consciousness: Consciousness | null;
+  measuredAt: string;
+  hasAlert: boolean;
+}
+
+export interface RoundingPatientInfo {
+  id: string;
+  patientNumber: string;
+  name: string;
+  age: number;
+  gender: Gender;
+  birthDate: string;
+}
+
+export interface RoundingBedInfo {
+  id: string;
+  roomNumber: string;
+  bedNumber: string;
+  roomName: string | null;
+}
+
+export interface RoundingAdmissionInfo {
+  diagnosis: string | null;
+  chiefComplaint: string | null;
+  admissionDate: string;
+  admissionDays: number;
+  admissionType: AdmissionType;
+  status: AdmissionStatus;
+  attendingDoctorId: string;
+}
+
+export interface RoundingPatient {
+  admissionId: string;
+  patient: RoundingPatientInfo;
+  bed: RoundingBedInfo;
+  admission: RoundingAdmissionInfo;
+  latestVitals: LatestVitals | null;
+  previousRoundNote: string | null;
+  existingRecordId: string | null;
+  isVisited: boolean;
+}
+
+export interface RoundingPatientList {
+  roundId: string;
+  roundNumber: string;
+  patients: RoundingPatient[];
+  totalPatients: number;
+  visitedCount: number;
+  progress: number;
+}


### PR DESCRIPTION
Closes #84

## Summary
- Add TypeScript types for rounding module (RoundType, RoundStatus, RoundPatientStatus, Round, RoundRecord, RoundingPatient, etc.)
- Implement API client with CRUD operations and state transitions (start, pause, resume, complete, cancel)
- Add React Query hooks for rounds, patients, and records management

## Changes Made
| File | Description |
|------|-------------|
| `src/types/rounding.ts` | Rounding module type definitions |
| `src/services/rounding-api.ts` | API client for rounding endpoints |
| `src/hooks/use-rounding.ts` | React Query hooks for rounding data |
| `src/types/index.ts` | Export rounding types |
| `src/services/index.ts` | Export rounding API |
| `src/hooks/index.ts` | Export rounding hooks |

## Test Plan
- [x] TypeScript compiles without errors
- [x] Next.js build succeeds
- [ ] Manual testing with backend API (requires #85 implementation)

Part of #34 (Frontend Tablet Rounding Interface)