### PR TITLE
feat(frontend): implement rounding session management page

### DIFF
--- a/apps/frontend/src/app/(dashboard)/rounding/[id]/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/rounding/[id]/page.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { use } from 'react';
+import Link from 'next/link';
+import {
+  useRound,
+  useRoundingPatients,
+  useFloors,
+  useStartRound,
+  usePauseRound,
+  useResumeRound,
+  useCompleteRound,
+  useCancelRound,
+} from '@/hooks';
+import { Card, CardContent, Badge, Button, Skeleton } from '@/components/ui';
+import { RoundingHeader } from '@/components/rounding';
+import { Users, Calendar, Clock, AlertCircle } from 'lucide-react';
+
+interface RoundingDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatTime(timeString: string | null): string {
+  if (!timeString) return 'Not scheduled';
+  return timeString.slice(0, 5);
+}
+
+export default function RoundingDetailPage({ params }: RoundingDetailPageProps) {
+  const { id } = use(params);
+  const { data: round, isLoading: roundLoading, error: roundError } = useRound(id);
+  const { data: patientList, isLoading: patientsLoading } = useRoundingPatients(id);
+  const { data: floors } = useFloors();
+
+  const startRound = useStartRound();
+  const pauseRound = usePauseRound();
+  const resumeRound = useResumeRound();
+  const completeRound = useCompleteRound();
+  const cancelRound = useCancelRound();
+
+  const isMutating =
+    startRound.isPending ||
+    pauseRound.isPending ||
+    resumeRound.isPending ||
+    completeRound.isPending ||
+    cancelRound.isPending;
+
+  const floorName = floors?.find((f) => f.id === round?.floorId)?.name;
+
+  if (roundLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-20 w-full" />
+        <div className="container mx-auto px-4 space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+            <Skeleton className="h-24 w-full" />
+          </div>
+          <Skeleton className="h-64 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (roundError || !round) {
+    return (
+      <div className="container mx-auto py-12 px-4">
+        <Card>
+          <CardContent className="p-12 text-center">
+            <AlertCircle className="h-12 w-12 mx-auto text-destructive mb-4" />
+            <h2 className="text-xl font-semibold mb-2">Failed to load round</h2>
+            <p className="text-muted-foreground mb-4">
+              The rounding session could not be found or an error occurred.
+            </p>
+            <Link href="/rounding">
+              <Button>Back to Sessions</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const progress = patientList
+    ? Math.round((patientList.visitedCount / patientList.totalPatients) * 100) || 0
+    : 0;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <RoundingHeader
+        round={round}
+        floorName={floorName}
+        onStart={() => startRound.mutate(id)}
+        onPause={() => pauseRound.mutate(id)}
+        onResume={() => resumeRound.mutate(id)}
+        onComplete={() => completeRound.mutate(id)}
+        onCancel={() => cancelRound.mutate(id)}
+        isLoading={isMutating}
+      />
+
+      <div className="container mx-auto px-4 py-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <Card>
+            <CardContent className="p-4 flex items-center gap-4">
+              <div className="p-3 bg-blue-100 rounded-full">
+                <Calendar className="h-6 w-6 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Scheduled Date</p>
+                <p className="font-semibold">{formatDate(round.scheduledDate)}</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 flex items-center gap-4">
+              <div className="p-3 bg-green-100 rounded-full">
+                <Clock className="h-6 w-6 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Scheduled Time</p>
+                <p className="font-semibold">{formatTime(round.scheduledTime)}</p>
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4 flex items-center gap-4">
+              <div className="p-3 bg-purple-100 rounded-full">
+                <Users className="h-6 w-6 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Patients</p>
+                <p className="font-semibold">
+                  {patientList ? `${patientList.visitedCount} / ${patientList.totalPatients}` : '-'}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {round.status === 'IN_PROGRESS' && patientList && (
+          <Card>
+            <CardContent className="p-4">
+              <div className="flex justify-between items-center mb-2">
+                <span className="text-sm font-medium">Round Progress</span>
+                <span className="text-sm text-muted-foreground">{progress}%</span>
+              </div>
+              <div className="w-full bg-gray-200 rounded-full h-3">
+                <div
+                  className="bg-yellow-500 h-3 rounded-full transition-all"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card>
+          <CardContent className="p-0">
+            <div className="p-4 border-b">
+              <h2 className="text-lg font-semibold">Patient List</h2>
+              <p className="text-sm text-muted-foreground">Patients to visit during this round</p>
+            </div>
+            {patientsLoading ? (
+              <div className="p-4 space-y-4">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <Skeleton key={i} className="h-16 w-full" />
+                ))}
+              </div>
+            ) : !patientList || patientList.patients.length === 0 ? (
+              <div className="p-12 text-center text-muted-foreground">
+                No patients assigned to this round.
+              </div>
+            ) : (
+              <div className="divide-y">
+                {patientList.patients.map((patient, index) => (
+                  <div
+                    key={patient.admissionId}
+                    className={`p-4 flex items-center justify-between ${
+                      patient.isVisited ? 'bg-green-50' : ''
+                    }`}
+                  >
+                    <div className="flex items-center gap-4">
+                      <div className="w-8 h-8 flex items-center justify-center bg-gray-100 rounded-full text-sm font-medium">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{patient.patient.name}</span>
+                          <Badge variant="outline">
+                            {patient.bed.roomNumber}-{patient.bed.bedNumber}
+                          </Badge>
+                          {patient.isVisited && <Badge variant="success">Visited</Badge>}
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          {patient.admission.diagnosis || 'No diagnosis'} | Day{' '}
+                          {patient.admission.admissionDays}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-4">
+                      {patient.latestVitals && (
+                        <div className="text-sm text-muted-foreground hidden md:flex gap-3">
+                          {patient.latestVitals.temperature && (
+                            <span>T: {patient.latestVitals.temperature}C</span>
+                          )}
+                          {patient.latestVitals.bloodPressure && (
+                            <span>BP: {patient.latestVitals.bloodPressure}</span>
+                          )}
+                          {patient.latestVitals.oxygenSaturation && (
+                            <span>SpO2: {patient.latestVitals.oxygenSaturation}%</span>
+                          )}
+                          {patient.latestVitals.hasAlert && (
+                            <Badge variant="destructive">Alert</Badge>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {round.notes && (
+          <Card>
+            <CardContent className="p-4">
+              <h3 className="font-semibold mb-2">Notes</h3>
+              <p className="text-muted-foreground whitespace-pre-wrap">{round.notes}</p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(dashboard)/rounding/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/rounding/page.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  useRounds,
+  useFloors,
+  useStartRound,
+  usePauseRound,
+  useResumeRound,
+  useCompleteRound,
+  useCreateRound,
+} from '@/hooks';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  LegacySelect,
+  Button,
+  Skeleton,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  Input,
+  Label,
+} from '@/components/ui';
+import { RoundingSessionCard } from '@/components/rounding';
+import { Plus, ChevronLeft, ChevronRight } from 'lucide-react';
+import type { FindRoundsParams, RoundStatus, RoundType, CreateRoundData } from '@/types';
+
+const statusOptions = [
+  { value: '', label: 'All Status' },
+  { value: 'PLANNED', label: 'Planned' },
+  { value: 'IN_PROGRESS', label: 'In Progress' },
+  { value: 'PAUSED', label: 'Paused' },
+  { value: 'COMPLETED', label: 'Completed' },
+  { value: 'CANCELLED', label: 'Cancelled' },
+];
+
+const roundTypeOptions = [
+  { value: '', label: 'All Types' },
+  { value: 'MORNING', label: 'Morning' },
+  { value: 'AFTERNOON', label: 'Afternoon' },
+  { value: 'EVENING', label: 'Evening' },
+  { value: 'NIGHT', label: 'Night' },
+];
+
+export default function RoundingSessionsPage() {
+  const [selectedFloorId, setSelectedFloorId] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [roundTypeFilter, setRoundTypeFilter] = useState('');
+  const [page, setPage] = useState(1);
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [newRoundData, setNewRoundData] = useState<Partial<CreateRoundData>>({
+    roundType: 'MORNING',
+    scheduledDate: new Date().toISOString().split('T')[0],
+  });
+  const limit = 12;
+
+  const { data: floors, isLoading: floorsLoading } = useFloors();
+
+  const params: FindRoundsParams = {
+    floorId: selectedFloorId || undefined,
+    status: (statusFilter as RoundStatus) || undefined,
+    roundType: (roundTypeFilter as RoundType) || undefined,
+    page,
+    limit,
+  };
+
+  const { data, isLoading, error } = useRounds(params);
+  const startRound = useStartRound();
+  const pauseRound = usePauseRound();
+  const resumeRound = useResumeRound();
+  const completeRound = useCompleteRound();
+  const createRound = useCreateRound();
+
+  const floorOptions = [
+    { value: '', label: 'All Floors' },
+    ...(floors?.map((floor) => ({
+      value: floor.id,
+      label: floor.name,
+    })) || []),
+  ];
+
+  const handleCreateRound = async () => {
+    if (!newRoundData.floorId || !newRoundData.roundType || !newRoundData.scheduledDate) {
+      return;
+    }
+
+    try {
+      await createRound.mutateAsync({
+        floorId: newRoundData.floorId,
+        roundType: newRoundData.roundType as RoundType,
+        scheduledDate: newRoundData.scheduledDate,
+        scheduledTime: newRoundData.scheduledTime,
+        leadDoctorId: 'current-user',
+      });
+      setIsCreateDialogOpen(false);
+      setNewRoundData({
+        roundType: 'MORNING',
+        scheduledDate: new Date().toISOString().split('T')[0],
+      });
+    } catch (err) {
+      console.error('Failed to create round:', err);
+    }
+  };
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Rounding Sessions</h1>
+        <Button onClick={() => setIsCreateDialogOpen(true)}>
+          <Plus className="h-4 w-4" />
+          New Session
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Filter Sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="w-full md:w-48">
+              {floorsLoading ? (
+                <Skeleton className="h-9 w-full" />
+              ) : (
+                <LegacySelect
+                  options={floorOptions}
+                  value={selectedFloorId}
+                  onChange={(e) => {
+                    setSelectedFloorId(e.target.value);
+                    setPage(1);
+                  }}
+                />
+              )}
+            </div>
+            <div className="w-full md:w-40">
+              <LegacySelect
+                options={statusOptions}
+                value={statusFilter}
+                onChange={(e) => {
+                  setStatusFilter(e.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+            <div className="w-full md:w-40">
+              <LegacySelect
+                options={roundTypeOptions}
+                value={roundTypeFilter}
+                onChange={(e) => {
+                  setRoundTypeFilter(e.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 w-full" />
+          ))}
+        </div>
+      ) : error ? (
+        <Card>
+          <CardContent className="p-12 text-center text-destructive">
+            Failed to load rounding sessions. Please try again.
+          </CardContent>
+        </Card>
+      ) : data?.data.length === 0 ? (
+        <Card>
+          <CardContent className="p-12 text-center text-muted-foreground">
+            No rounding sessions found.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {data?.data.map((round) => (
+            <RoundingSessionCard
+              key={round.id}
+              round={round}
+              onStart={(id) => startRound.mutate(id)}
+              onPause={(id) => pauseRound.mutate(id)}
+              onResume={(id) => resumeRound.mutate(id)}
+              onComplete={(id) => completeRound.mutate(id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {data && data.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, data.total)} of {data.total}{' '}
+            sessions
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => p - 1)}
+              disabled={page <= 1}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Previous
+            </Button>
+            <span className="text-sm">
+              Page {page} of {data.totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={page >= data.totalPages}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create New Rounding Session</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="floor">Floor</Label>
+              {floorsLoading ? (
+                <Skeleton className="h-9 w-full" />
+              ) : (
+                <LegacySelect
+                  options={
+                    floors?.map((floor) => ({
+                      value: floor.id,
+                      label: floor.name,
+                    })) || []
+                  }
+                  value={newRoundData.floorId || ''}
+                  onChange={(e) =>
+                    setNewRoundData((prev) => ({ ...prev, floorId: e.target.value }))
+                  }
+                />
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="roundType">Round Type</Label>
+              <LegacySelect
+                options={[
+                  { value: 'MORNING', label: 'Morning' },
+                  { value: 'AFTERNOON', label: 'Afternoon' },
+                  { value: 'EVENING', label: 'Evening' },
+                  { value: 'NIGHT', label: 'Night' },
+                ]}
+                value={newRoundData.roundType || 'MORNING'}
+                onChange={(e) =>
+                  setNewRoundData((prev) => ({ ...prev, roundType: e.target.value as RoundType }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="scheduledDate">Scheduled Date</Label>
+              <Input
+                id="scheduledDate"
+                type="date"
+                value={newRoundData.scheduledDate || ''}
+                onChange={(e) =>
+                  setNewRoundData((prev) => ({ ...prev, scheduledDate: e.target.value }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="scheduledTime">Scheduled Time (Optional)</Label>
+              <Input
+                id="scheduledTime"
+                type="time"
+                value={newRoundData.scheduledTime || ''}
+                onChange={(e) =>
+                  setNewRoundData((prev) => ({ ...prev, scheduledTime: e.target.value }))
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsCreateDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreateRound}
+              disabled={!newRoundData.floorId || createRound.isPending}
+            >
+              Create Session
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rounding/index.ts
+++ b/apps/frontend/src/components/rounding/index.ts
@@ -1,0 +1,2 @@
+export { RoundingSessionCard } from './rounding-session-card';
+export { RoundingHeader } from './rounding-header';

--- a/apps/frontend/src/components/rounding/rounding-header.tsx
+++ b/apps/frontend/src/components/rounding/rounding-header.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { Button, Badge } from '@/components/ui';
+import { Play, Pause, CheckCircle, X, ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import type { Round, RoundStatus, RoundType } from '@/types';
+
+interface RoundingHeaderProps {
+  round: Round;
+  floorName?: string;
+  onStart?: () => void;
+  onPause?: () => void;
+  onResume?: () => void;
+  onComplete?: () => void;
+  onCancel?: () => void;
+  isLoading?: boolean;
+}
+
+const statusConfig: Record<
+  RoundStatus,
+  { label: string; variant: 'default' | 'secondary' | 'success' | 'warning' | 'destructive' }
+> = {
+  PLANNED: { label: 'Planned', variant: 'secondary' },
+  IN_PROGRESS: { label: 'In Progress', variant: 'warning' },
+  PAUSED: { label: 'Paused', variant: 'default' },
+  COMPLETED: { label: 'Completed', variant: 'success' },
+  CANCELLED: { label: 'Cancelled', variant: 'destructive' },
+};
+
+const roundTypeLabels: Record<RoundType, string> = {
+  MORNING: 'Morning',
+  AFTERNOON: 'Afternoon',
+  EVENING: 'Evening',
+  NIGHT: 'Night',
+};
+
+export function RoundingHeader({
+  round,
+  floorName,
+  onStart,
+  onPause,
+  onResume,
+  onComplete,
+  onCancel,
+  isLoading = false,
+}: RoundingHeaderProps) {
+  const status = statusConfig[round.status];
+  const canStart = round.validTransitions?.includes('IN_PROGRESS') ?? round.status === 'PLANNED';
+  const canPause = round.validTransitions?.includes('PAUSED') ?? round.status === 'IN_PROGRESS';
+  const canResume = round.validTransitions?.includes('IN_PROGRESS') ?? round.status === 'PAUSED';
+  const canComplete =
+    round.validTransitions?.includes('COMPLETED') ?? round.status === 'IN_PROGRESS';
+  const canCancel =
+    round.validTransitions?.includes('CANCELLED') ?? ['PLANNED', 'PAUSED'].includes(round.status);
+
+  return (
+    <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 p-4 bg-white border-b sticky top-0 z-10">
+      <div className="flex items-center gap-4">
+        <Link href="/rounding">
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+        </Link>
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-lg font-bold">{round.roundNumber}</h1>
+            <Badge variant={status.variant}>{status.label}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {floorName && `${floorName} | `}
+            {roundTypeLabels[round.roundType]} Round
+          </p>
+        </div>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        {canStart && onStart && (
+          <Button onClick={onStart} disabled={isLoading}>
+            <Play className="h-4 w-4" />
+            Start Round
+          </Button>
+        )}
+        {canPause && onPause && (
+          <Button variant="outline" onClick={onPause} disabled={isLoading}>
+            <Pause className="h-4 w-4" />
+            Pause
+          </Button>
+        )}
+        {canResume && onResume && (
+          <Button onClick={onResume} disabled={isLoading}>
+            <Play className="h-4 w-4" />
+            Resume
+          </Button>
+        )}
+        {canComplete && onComplete && (
+          <Button onClick={onComplete} disabled={isLoading}>
+            <CheckCircle className="h-4 w-4" />
+            Complete
+          </Button>
+        )}
+        {canCancel && onCancel && (
+          <Button variant="destructive" onClick={onCancel} disabled={isLoading}>
+            <X className="h-4 w-4" />
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/rounding/rounding-session-card.tsx
+++ b/apps/frontend/src/components/rounding/rounding-session-card.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import Link from 'next/link';
+import { Card, CardContent, Badge, Button } from '@/components/ui';
+import { Calendar, Clock, Users, Play, Pause, CheckCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { Round, RoundStatus, RoundType } from '@/types';
+
+interface RoundingSessionCardProps {
+  round: Round;
+  onStart?: (id: string) => void;
+  onPause?: (id: string) => void;
+  onResume?: (id: string) => void;
+  onComplete?: (id: string) => void;
+}
+
+const statusConfig: Record<
+  RoundStatus,
+  { label: string; variant: 'default' | 'secondary' | 'success' | 'warning' | 'destructive' }
+> = {
+  PLANNED: { label: 'Planned', variant: 'secondary' },
+  IN_PROGRESS: { label: 'In Progress', variant: 'warning' },
+  PAUSED: { label: 'Paused', variant: 'default' },
+  COMPLETED: { label: 'Completed', variant: 'success' },
+  CANCELLED: { label: 'Cancelled', variant: 'destructive' },
+};
+
+const roundTypeLabels: Record<RoundType, string> = {
+  MORNING: 'Morning',
+  AFTERNOON: 'Afternoon',
+  EVENING: 'Evening',
+  NIGHT: 'Night',
+};
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function formatTime(timeString: string | null): string {
+  if (!timeString) return '-';
+  return timeString.slice(0, 5);
+}
+
+export function RoundingSessionCard({
+  round,
+  onStart,
+  onPause,
+  onResume,
+  onComplete,
+}: RoundingSessionCardProps) {
+  const status = statusConfig[round.status];
+  const visitedCount = round.records?.filter((r) => r.visitedAt !== null).length ?? 0;
+  const totalCount = round.records?.length ?? 0;
+  const progress = totalCount > 0 ? Math.round((visitedCount / totalCount) * 100) : 0;
+
+  return (
+    <Card
+      className={cn(
+        'transition-shadow hover:shadow-md',
+        round.status === 'IN_PROGRESS' && 'border-yellow-300 bg-yellow-50/50',
+      )}
+    >
+      <CardContent className="p-4">
+        <div className="flex justify-between items-start mb-3">
+          <div>
+            <Link href={`/rounding/${round.id}`} className="hover:underline">
+              <h3 className="font-semibold text-lg">{round.roundNumber}</h3>
+            </Link>
+            <p className="text-sm text-muted-foreground">
+              {roundTypeLabels[round.roundType]} Round
+            </p>
+          </div>
+          <Badge variant={status.variant}>{status.label}</Badge>
+        </div>
+
+        <div className="space-y-2 text-sm text-muted-foreground mb-4">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4" />
+            <span>{formatDate(round.scheduledDate)}</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <Clock className="h-4 w-4" />
+            <span>{formatTime(round.scheduledTime)}</span>
+          </div>
+          {totalCount > 0 && (
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              <span>
+                {visitedCount} / {totalCount} patients
+              </span>
+            </div>
+          )}
+        </div>
+
+        {round.status === 'IN_PROGRESS' && totalCount > 0 && (
+          <div className="mb-4">
+            <div className="flex justify-between text-xs mb-1">
+              <span>Progress</span>
+              <span>{progress}%</span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div
+                className="bg-yellow-500 h-2 rounded-full transition-all"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          {round.status === 'PLANNED' && onStart && (
+            <Button size="sm" className="flex-1" onClick={() => onStart(round.id)}>
+              <Play className="h-4 w-4" />
+              Start
+            </Button>
+          )}
+          {round.status === 'IN_PROGRESS' && (
+            <>
+              {onPause && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
+                  onClick={() => onPause(round.id)}
+                >
+                  <Pause className="h-4 w-4" />
+                  Pause
+                </Button>
+              )}
+              {onComplete && (
+                <Button size="sm" className="flex-1" onClick={() => onComplete(round.id)}>
+                  <CheckCircle className="h-4 w-4" />
+                  Complete
+                </Button>
+              )}
+            </>
+          )}
+          {round.status === 'PAUSED' && onResume && (
+            <Button size="sm" className="flex-1" onClick={() => onResume(round.id)}>
+              <Play className="h-4 w-4" />
+              Resume
+            </Button>
+          )}
+          <Link href={`/rounding/${round.id}`} className="flex-1">
+            <Button variant="outline" size="sm" className="w-full">
+              View Details
+            </Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Closes #85

## Summary
- Add RoundingSessionCard component with status badges and action buttons
- Add RoundingHeader component with session controls (start, pause, resume, complete, cancel)
- Implement rounding sessions list page with floor/status/type filters
- Implement session detail page with progress tracking and patient list
- Support session status transitions via API hooks
- Add create new session dialog

## Test Plan
- Verify session list page loads with proper pagination
- Test filter functionality (floor, status, type)
- Test session creation dialog
- Verify session detail page displays patient list
- Test session status transitions (start, pause, resume, complete)
- Verify responsive design on tablet screens (768px+)