### PR TITLE
feat(rounding): implement patient list cards and round record form

### DIFF
--- a/apps/frontend/src/components/rounding/index.ts
+++ b/apps/frontend/src/components/rounding/index.ts
@@ -1,2 +1,4 @@
 export { RoundingSessionCard } from './rounding-session-card';
 export { RoundingHeader } from './rounding-header';
+export { RoundingPatientCard } from './rounding-patient-card';
+export { RoundRecordForm } from './round-record-form';

--- a/apps/frontend/src/components/rounding/round-record-form.tsx
+++ b/apps/frontend/src/components/rounding/round-record-form.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useEffect, useCallback, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  Card,
+  CardContent,
+  Button,
+  Label,
+  Textarea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Badge,
+} from '@/components/ui';
+import type { RoundingPatient, RoundPatientStatus, UpdateRoundRecordData } from '@/types';
+
+interface RoundRecordFormData {
+  patientStatus: RoundPatientStatus | '';
+  chiefComplaint: string;
+  observation: string;
+  assessment: string;
+  plan: string;
+  orders: string;
+}
+
+interface RoundRecordFormProps {
+  patient: RoundingPatient;
+  onSave: (data: UpdateRoundRecordData) => void;
+  onSkip: () => void;
+  isSaving?: boolean;
+}
+
+const patientStatusOptions: { value: RoundPatientStatus; label: string; color: string }[] = [
+  { value: 'STABLE', label: 'Stable', color: 'bg-blue-100 text-blue-700' },
+  { value: 'IMPROVING', label: 'Improving', color: 'bg-green-100 text-green-700' },
+  { value: 'DECLINING', label: 'Declining', color: 'bg-yellow-100 text-yellow-700' },
+  { value: 'CRITICAL', label: 'Critical', color: 'bg-red-100 text-red-700' },
+];
+
+export function RoundRecordForm({
+  patient,
+  onSave,
+  onSkip,
+  isSaving = false,
+}: RoundRecordFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const autoSaveTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const { register, handleSubmit, watch, setValue, reset } = useForm<RoundRecordFormData>({
+    defaultValues: {
+      patientStatus: '',
+      chiefComplaint: '',
+      observation: '',
+      assessment: '',
+      plan: '',
+      orders: '',
+    },
+  });
+
+  const formData = watch();
+
+  const saveData = useCallback(() => {
+    const data: UpdateRoundRecordData = {};
+    if (formData.patientStatus) data.patientStatus = formData.patientStatus as RoundPatientStatus;
+    if (formData.chiefComplaint) data.chiefComplaint = formData.chiefComplaint;
+    if (formData.observation) data.observation = formData.observation;
+    if (formData.assessment) data.assessment = formData.assessment;
+    if (formData.plan) data.plan = formData.plan;
+    if (formData.orders) data.orders = formData.orders;
+
+    if (Object.keys(data).length > 0) {
+      onSave(data);
+    }
+  }, [formData, onSave]);
+
+  useEffect(() => {
+    if (autoSaveTimerRef.current) {
+      clearTimeout(autoSaveTimerRef.current);
+    }
+    autoSaveTimerRef.current = setTimeout(() => {
+      const hasData =
+        formData.patientStatus ||
+        formData.chiefComplaint ||
+        formData.observation ||
+        formData.assessment ||
+        formData.plan ||
+        formData.orders;
+      if (hasData) {
+        saveData();
+      }
+    }, 3000);
+
+    return () => {
+      if (autoSaveTimerRef.current) {
+        clearTimeout(autoSaveTimerRef.current);
+      }
+    };
+  }, [formData, saveData]);
+
+  useEffect(() => {
+    reset({
+      patientStatus: '',
+      chiefComplaint: '',
+      observation: '',
+      assessment: '',
+      plan: '',
+      orders: '',
+    });
+  }, [patient.admissionId, reset]);
+
+  const onSubmit = (data: RoundRecordFormData) => {
+    const submitData: UpdateRoundRecordData = {};
+    if (data.patientStatus) submitData.patientStatus = data.patientStatus as RoundPatientStatus;
+    if (data.chiefComplaint) submitData.chiefComplaint = data.chiefComplaint;
+    if (data.observation) submitData.observation = data.observation;
+    if (data.assessment) submitData.assessment = data.assessment;
+    if (data.plan) submitData.plan = data.plan;
+    if (data.orders) submitData.orders = data.orders;
+
+    onSave(submitData);
+  };
+
+  return (
+    <Card className="h-full flex flex-col">
+      <CardContent className="p-4 flex-1 overflow-y-auto">
+        <div className="mb-4 p-3 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="font-semibold text-lg">{patient.patient.name}</h3>
+              <p className="text-sm text-muted-foreground">
+                {patient.bed.roomNumber}-{patient.bed.bedNumber} | Day{' '}
+                {patient.admission.admissionDays}
+              </p>
+            </div>
+            {patient.latestVitals?.hasAlert && <Badge variant="destructive">Vital Alert</Badge>}
+          </div>
+          {patient.admission.diagnosis && (
+            <p className="mt-2 text-sm">{patient.admission.diagnosis}</p>
+          )}
+          {patient.previousRoundNote && (
+            <div className="mt-2 pt-2 border-t">
+              <span className="text-xs font-medium text-muted-foreground">Previous Round: </span>
+              <span className="text-sm">{patient.previousRoundNote}</span>
+            </div>
+          )}
+        </div>
+
+        <form ref={formRef} onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label>Patient Status</Label>
+            <Select
+              value={formData.patientStatus}
+              onValueChange={(value) => setValue('patientStatus', value as RoundPatientStatus)}
+            >
+              <SelectTrigger className="h-12">
+                <SelectValue placeholder="Select patient status" />
+              </SelectTrigger>
+              <SelectContent>
+                {patientStatusOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    <div className="flex items-center gap-2">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${option.color}`}>
+                        {option.label}
+                      </span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="chiefComplaint">Chief Complaint</Label>
+            <Textarea
+              id="chiefComplaint"
+              {...register('chiefComplaint')}
+              placeholder="Main presenting complaint..."
+              className="min-h-[60px] text-base"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="observation">Observation</Label>
+            <Textarea
+              id="observation"
+              {...register('observation')}
+              placeholder="Clinical observations..."
+              className="min-h-[80px] text-base"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="assessment">Assessment</Label>
+            <Textarea
+              id="assessment"
+              {...register('assessment')}
+              placeholder="Clinical assessment..."
+              className="min-h-[60px] text-base"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plan">Plan</Label>
+            <Textarea
+              id="plan"
+              {...register('plan')}
+              placeholder="Treatment plan..."
+              className="min-h-[60px] text-base"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="orders">Orders</Label>
+            <Textarea
+              id="orders"
+              {...register('orders')}
+              placeholder="Clinical orders..."
+              className="min-h-[60px] text-base"
+            />
+          </div>
+        </form>
+      </CardContent>
+
+      <div className="p-4 border-t flex gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          className="flex-1 h-12 text-base"
+          onClick={onSkip}
+          disabled={isSaving}
+        >
+          Skip
+        </Button>
+        <Button
+          type="submit"
+          className="flex-1 h-12 text-base"
+          onClick={handleSubmit(onSubmit)}
+          disabled={isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save & Next'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/rounding/rounding-patient-card.tsx
+++ b/apps/frontend/src/components/rounding/rounding-patient-card.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Card, Badge } from '@/components/ui';
+import { cn } from '@/lib/utils';
+import type { RoundingPatient } from '@/types';
+
+interface RoundingPatientCardProps {
+  patient: RoundingPatient;
+  index: number;
+  isSelected?: boolean;
+  onClick?: () => void;
+}
+
+export function RoundingPatientCard({
+  patient,
+  index,
+  isSelected = false,
+  onClick,
+}: RoundingPatientCardProps) {
+  return (
+    <Card
+      className={cn(
+        'p-4 cursor-pointer transition-all touch-manipulation',
+        isSelected && 'ring-2 ring-primary',
+        patient.isVisited && 'bg-green-50 border-green-200',
+        !patient.isVisited && 'hover:bg-gray-50',
+      )}
+      onClick={onClick}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              'w-8 h-8 flex items-center justify-center rounded-full text-sm font-medium shrink-0',
+              patient.isVisited ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-700',
+            )}
+          >
+            {index + 1}
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-medium truncate">{patient.patient.name}</span>
+              <Badge variant="outline" className="text-xs shrink-0">
+                {patient.bed.roomNumber}-{patient.bed.bedNumber}
+              </Badge>
+              {patient.isVisited && (
+                <Badge variant="success" className="text-xs shrink-0">
+                  Visited
+                </Badge>
+              )}
+            </div>
+            <p className="text-sm text-muted-foreground truncate">
+              {patient.admission.diagnosis || 'No diagnosis'} | Day{' '}
+              {patient.admission.admissionDays}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          {patient.latestVitals?.hasAlert && (
+            <Badge variant="destructive" className="text-xs">
+              Alert
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {patient.latestVitals && (
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+          {patient.latestVitals.temperature && <span>T: {patient.latestVitals.temperature}°C</span>}
+          {patient.latestVitals.bloodPressure && (
+            <span>BP: {patient.latestVitals.bloodPressure}</span>
+          )}
+          {patient.latestVitals.oxygenSaturation && (
+            <span>SpO2: {patient.latestVitals.oxygenSaturation}%</span>
+          )}
+          {patient.latestVitals.pulseRate && <span>PR: {patient.latestVitals.pulseRate}</span>}
+        </div>
+      )}
+
+      {patient.previousRoundNote && (
+        <div className="mt-3 p-2 bg-gray-50 rounded text-sm">
+          <span className="font-medium text-muted-foreground">Previous: </span>
+          <span className="text-gray-700">{patient.previousRoundNote}</span>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/ui/index.ts
+++ b/apps/frontend/src/components/ui/index.ts
@@ -47,3 +47,4 @@ export {
   DialogTitle,
   DialogDescription,
 } from './dialog';
+export { Textarea } from './textarea';

--- a/apps/frontend/src/components/ui/textarea.tsx
+++ b/apps/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<'textarea'>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };


### PR DESCRIPTION
Closes #86

## Summary
- Add RoundingPatientCard component for displaying patient info with vitals, diagnosis, and previous round notes
- Add RoundRecordForm component for capturing round observations with patient status, chief complaint, observation, assessment, plan, and orders fields
- Add Textarea UI component for multi-line text input
- Update rounding detail page with new components and split-screen patient selection view
- Support auto-save (3-second debounce) and Save & Next workflow for efficient rounding

## Test Plan
- [ ] Navigate to a rounding session detail page
- [ ] Start a round and verify patient list is displayed with RoundingPatientCard components
- [ ] Click a patient card to select it and verify RoundRecordForm appears
- [ ] Fill in the record form and click "Save & Next" - verify form is saved and moves to next patient
- [ ] Click "Skip" and verify it moves to the next patient without saving
- [ ] Verify navigation buttons (Previous/Next) work correctly
- [ ] Test auto-save by making changes and waiting 3 seconds
- [ ] Verify the form works well on tablet-sized screens (768px+)