### PR TITLE
test(frontend): add comprehensive cypress e2e tests for main workflows

### DIFF
--- a/apps/frontend/cypress/e2e/auth/role-based-access.cy.ts
+++ b/apps/frontend/cypress/e2e/auth/role-based-access.cy.ts
@@ -1,0 +1,108 @@
+/// <reference types="cypress" />
+
+/**
+ * Role-Based Access Control E2E Tests
+ *
+ * Tests that different user roles have appropriate access to various
+ * parts of the application.
+ */
+describe('Role-Based Access Control', () => {
+  describe('Admin Access', () => {
+    beforeEach(() => {
+      cy.fixture('users').then((users) => {
+        cy.login(users.admin.username, users.admin.password);
+      });
+    });
+
+    it('should access patient list', () => {
+      cy.visit('/patients');
+      cy.url().should('include', '/patients');
+      cy.contains('Patient List').should('be.visible');
+    });
+
+    it('should access room status', () => {
+      cy.visit('/rooms');
+      cy.url().should('include', '/rooms');
+    });
+
+    it('should access rounding sessions', () => {
+      cy.visit('/rounding');
+      cy.url().should('include', '/rounding');
+      cy.contains('Rounding Sessions').should('be.visible');
+    });
+  });
+
+  describe('Doctor Access', () => {
+    beforeEach(() => {
+      cy.fixture('users').then((users) => {
+        cy.login(users.doctor.username, users.doctor.password);
+      });
+    });
+
+    it('should access patient list', () => {
+      cy.visit('/patients');
+      cy.url().should('include', '/patients');
+      cy.contains('Patient List').should('be.visible');
+    });
+
+    it('should access rounding sessions', () => {
+      cy.visit('/rounding');
+      cy.url().should('include', '/rounding');
+      cy.contains('Rounding Sessions').should('be.visible');
+    });
+
+    it('should be able to view patient details', () => {
+      cy.visit('/patients');
+      cy.get('table tbody tr', { timeout: 10000 }).first().should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+      cy.contains('Patient Details').should('be.visible');
+    });
+  });
+
+  describe('Nurse Access', () => {
+    beforeEach(() => {
+      cy.fixture('users').then((users) => {
+        cy.login(users.nurse.username, users.nurse.password);
+      });
+    });
+
+    it('should access patient list', () => {
+      cy.visit('/patients');
+      cy.url().should('include', '/patients');
+      cy.contains('Patient List').should('be.visible');
+    });
+
+    it('should access room status', () => {
+      cy.visit('/rooms');
+      cy.url().should('include', '/rooms');
+    });
+
+    it('should be able to view patient details', () => {
+      cy.visit('/patients');
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+      cy.contains('Patient Details').should('be.visible');
+    });
+  });
+
+  describe('Unauthenticated Access', () => {
+    beforeEach(() => {
+      cy.clearLocalStorage('auth-storage');
+    });
+
+    it('should redirect to login when accessing patients page', () => {
+      cy.visit('/patients');
+      cy.url().should('include', '/login');
+    });
+
+    it('should redirect to login when accessing rooms page', () => {
+      cy.visit('/rooms');
+      cy.url().should('include', '/login');
+    });
+
+    it('should redirect to login when accessing rounding page', () => {
+      cy.visit('/rounding');
+      cy.url().should('include', '/login');
+    });
+  });
+});

--- a/apps/frontend/cypress/e2e/patients/patient-detail.cy.ts
+++ b/apps/frontend/cypress/e2e/patients/patient-detail.cy.ts
@@ -1,0 +1,81 @@
+/// <reference types="cypress" />
+
+describe('Patient Detail', () => {
+  beforeEach(() => {
+    cy.fixture('users').then((users) => {
+      cy.login(users.admin.username, users.admin.password);
+    });
+  });
+
+  describe('Patient Information Display', () => {
+    it('should display patient details when navigating from list', () => {
+      cy.visit('/patients');
+
+      // Wait for patient list to load
+      cy.get('table tbody tr', { timeout: 10000 }).first().should('be.visible');
+
+      // Click view button on first patient
+      cy.get('table tbody tr').first().contains('View').click();
+
+      // Wait for detail page to load
+      cy.contains('Patient Details', { timeout: 10000 }).should('be.visible');
+
+      // Verify patient information is displayed
+      cy.contains('Birth Date').should('be.visible');
+      cy.contains('Gender').should('be.visible');
+      cy.contains('Blood Type').should('be.visible');
+      cy.contains('Phone').should('be.visible');
+      cy.contains('Address').should('be.visible');
+    });
+
+    it('should display emergency contact information', () => {
+      cy.visit('/patients');
+      cy.get('table tbody tr', { timeout: 10000 }).first().contains('View').click();
+
+      cy.contains('Emergency Contact').should('be.visible');
+    });
+
+    it('should display admission history', () => {
+      cy.visit('/patients');
+      cy.get('table tbody tr', { timeout: 10000 }).first().contains('View').click();
+
+      cy.contains('Admission History').should('be.visible');
+    });
+
+    it('should have back button that returns to patient list', () => {
+      cy.visit('/patients');
+      cy.get('table tbody tr', { timeout: 10000 }).first().contains('View').click();
+
+      cy.contains('Back').click();
+      cy.url().should('include', '/patients');
+      cy.url().should('not.include', '/patients/');
+    });
+  });
+
+  describe('Quick Actions', () => {
+    it('should display quick actions card', () => {
+      cy.visit('/patients');
+      cy.get('table tbody tr', { timeout: 10000 }).first().contains('View').click();
+
+      cy.contains('Quick Actions').should('be.visible');
+      cy.contains('New Admission').should('be.visible');
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle non-existent patient gracefully', () => {
+      cy.visit('/patients/00000000-0000-0000-0000-000000000000');
+
+      // Should show error message
+      cy.contains('Failed to load patient information', { timeout: 10000 }).should('be.visible');
+      cy.contains('Back to Patient List').should('be.visible');
+    });
+
+    it('should navigate back from error page', () => {
+      cy.visit('/patients/00000000-0000-0000-0000-000000000000');
+
+      cy.contains('Back to Patient List', { timeout: 10000 }).click();
+      cy.url().should('eq', Cypress.config().baseUrl + '/patients');
+    });
+  });
+});

--- a/apps/frontend/cypress/e2e/patients/patient-list.cy.ts
+++ b/apps/frontend/cypress/e2e/patients/patient-list.cy.ts
@@ -1,0 +1,101 @@
+/// <reference types="cypress" />
+
+describe('Patient List', () => {
+  beforeEach(() => {
+    cy.fixture('users').then((users) => {
+      cy.login(users.admin.username, users.admin.password);
+    });
+    cy.visit('/patients');
+  });
+
+  describe('Page Load', () => {
+    it('should display patient list page with all required elements', () => {
+      // Page title
+      cy.contains('Patient List').should('be.visible');
+
+      // Search and filter card
+      cy.contains('Search and Filter').should('be.visible');
+      cy.get('input[placeholder*="Search"]').should('be.visible');
+
+      // Table headers
+      cy.contains('Patient Number').should('be.visible');
+      cy.contains('Name').should('be.visible');
+      cy.contains('Birth Date').should('be.visible');
+      cy.contains('Gender').should('be.visible');
+    });
+
+    it('should require authentication', () => {
+      cy.clearLocalStorage('auth-storage');
+      cy.visit('/patients');
+      cy.url().should('include', '/login');
+    });
+  });
+
+  describe('Search and Filter', () => {
+    it('should filter patients by search query', () => {
+      cy.get('input[placeholder*="Search"]').type('John');
+
+      // Wait for debounce and API call
+      cy.wait(500);
+
+      // Should show filtered results or no results message
+      cy.get('table tbody tr').should('exist');
+    });
+
+    it('should filter patients by gender', () => {
+      // Select gender filter
+      cy.get('select').first().select('MALE');
+
+      // Wait for filter to apply
+      cy.wait(300);
+
+      // All visible patients should be male
+      cy.get('table tbody').then(($tbody) => {
+        if ($tbody.find('tr').length > 0) {
+          cy.get('table tbody tr').each(($row) => {
+            cy.wrap($row).contains('Male');
+          });
+        }
+      });
+    });
+
+    it('should clear search and show all patients', () => {
+      // First search
+      cy.get('input[placeholder*="Search"]').type('TestQuery');
+      cy.wait(500);
+
+      // Clear search
+      cy.get('input[placeholder*="Search"]').clear();
+      cy.wait(500);
+
+      // Should show patient list again
+      cy.get('table').should('be.visible');
+    });
+  });
+
+  describe('Patient Navigation', () => {
+    it('should navigate to patient detail page when clicking View button', () => {
+      // Wait for table to load
+      cy.get('table tbody tr').first().should('be.visible');
+
+      // Click view button on first patient
+      cy.get('table tbody tr').first().contains('View').click();
+
+      // Should navigate to patient detail page
+      cy.url().should('include', '/patients/');
+      cy.contains('Patient Details').should('be.visible');
+    });
+  });
+
+  describe('Pagination', () => {
+    it('should show pagination when there are many patients', () => {
+      // If pagination exists, test it
+      cy.get('body').then(($body) => {
+        if ($body.find('button:contains("Next")').length > 0) {
+          cy.contains('Next').should('be.visible');
+          cy.contains('Previous').should('be.visible');
+        }
+      });
+    });
+  });
+});

--- a/apps/frontend/cypress/e2e/rooms/room-status.cy.ts
+++ b/apps/frontend/cypress/e2e/rooms/room-status.cy.ts
@@ -1,0 +1,38 @@
+/// <reference types="cypress" />
+
+describe('Room Status', () => {
+  beforeEach(() => {
+    cy.fixture('users').then((users) => {
+      cy.login(users.admin.username, users.admin.password);
+    });
+    cy.visit('/rooms');
+  });
+
+  describe('Page Load', () => {
+    it('should display room status page', () => {
+      // Page should load without errors
+      cy.url().should('include', '/rooms');
+
+      // Wait for content to load
+      cy.wait(500);
+
+      // Page should have some content
+      cy.get('body').should('not.be.empty');
+    });
+
+    it('should require authentication', () => {
+      cy.clearLocalStorage('auth-storage');
+      cy.visit('/rooms');
+      cy.url().should('include', '/login');
+    });
+  });
+
+  describe('Available Rooms', () => {
+    it('should navigate to available rooms page', () => {
+      cy.visit('/rooms/available');
+
+      // Should load available rooms page
+      cy.url().should('include', '/rooms/available');
+    });
+  });
+});

--- a/apps/frontend/cypress/e2e/rounding/rounding-detail.cy.ts
+++ b/apps/frontend/cypress/e2e/rounding/rounding-detail.cy.ts
@@ -1,0 +1,71 @@
+/// <reference types="cypress" />
+
+describe('Rounding Detail', () => {
+  beforeEach(() => {
+    cy.fixture('users').then((users) => {
+      cy.login(users.doctor.username, users.doctor.password);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle non-existent round gracefully', () => {
+      cy.visit('/rounding/00000000-0000-0000-0000-000000000000');
+
+      // Should show error message
+      cy.contains('Failed to load round', { timeout: 10000 }).should('be.visible');
+      cy.contains('Back to Sessions').should('be.visible');
+    });
+
+    it('should navigate back from error page', () => {
+      cy.visit('/rounding/00000000-0000-0000-0000-000000000000');
+
+      cy.contains('Back to Sessions', { timeout: 10000 }).click();
+      cy.url().should('include', '/rounding');
+      cy.url().should('not.include', '/rounding/00000000');
+    });
+  });
+
+  describe('Round Information Display', () => {
+    it('should display round detail page elements when accessed from list', () => {
+      cy.visit('/rounding');
+
+      // Wait for page to load
+      cy.wait(1000);
+
+      // Check if any session cards exist to click
+      cy.get('body').then(($body) => {
+        // Look for any clickable card or link that might navigate to detail
+        const cards = $body.find('a[href*="/rounding/"]');
+        if (cards.length > 0) {
+          cy.wrap(cards.first()).click();
+
+          // Verify detail page elements
+          cy.contains('Scheduled Date').should('be.visible');
+          cy.contains('Scheduled Time').should('be.visible');
+          cy.contains('Patients').should('be.visible');
+        } else {
+          cy.log('No rounding sessions available to test detail view');
+        }
+      });
+    });
+  });
+
+  describe('Patient List in Round', () => {
+    it('should display patient list section', () => {
+      cy.visit('/rounding');
+
+      cy.wait(1000);
+
+      cy.get('body').then(($body) => {
+        const cards = $body.find('a[href*="/rounding/"]');
+        if (cards.length > 0) {
+          cy.wrap(cards.first()).click();
+
+          cy.contains('Patient List').should('be.visible');
+        } else {
+          cy.log('No rounding sessions available to test patient list');
+        }
+      });
+    });
+  });
+});

--- a/apps/frontend/cypress/e2e/rounding/rounding-sessions.cy.ts
+++ b/apps/frontend/cypress/e2e/rounding/rounding-sessions.cy.ts
@@ -1,0 +1,92 @@
+/// <reference types="cypress" />
+
+describe('Rounding Sessions', () => {
+  beforeEach(() => {
+    cy.fixture('users').then((users) => {
+      cy.login(users.doctor.username, users.doctor.password);
+    });
+    cy.visit('/rounding');
+  });
+
+  describe('Page Load', () => {
+    it('should display rounding sessions page with required elements', () => {
+      cy.contains('Rounding Sessions').should('be.visible');
+      cy.contains('Filter Sessions').should('be.visible');
+      cy.contains('New Session').should('be.visible');
+    });
+
+    it('should require authentication', () => {
+      cy.clearLocalStorage('auth-storage');
+      cy.visit('/rounding');
+      cy.url().should('include', '/login');
+    });
+  });
+
+  describe('Filter Sessions', () => {
+    it('should have floor filter dropdown', () => {
+      cy.get('select').should('have.length.at.least', 1);
+    });
+
+    it('should have status filter dropdown', () => {
+      cy.contains('All Status').should('be.visible');
+    });
+
+    it('should have round type filter dropdown', () => {
+      cy.contains('All Types').should('be.visible');
+    });
+
+    it('should filter sessions by status', () => {
+      // Select specific status
+      cy.get('select').eq(1).select('IN_PROGRESS');
+
+      // Wait for filter to apply
+      cy.wait(500);
+
+      // Should show filtered results or no results message
+      cy.get('body').should('contain.text', 'Rounding');
+    });
+  });
+
+  describe('Create New Session', () => {
+    it('should open create dialog when clicking New Session button', () => {
+      cy.contains('New Session').click();
+
+      cy.contains('Create New Rounding Session').should('be.visible');
+      cy.contains('Floor').should('be.visible');
+      cy.contains('Round Type').should('be.visible');
+      cy.contains('Scheduled Date').should('be.visible');
+    });
+
+    it('should close dialog when clicking Cancel', () => {
+      cy.contains('New Session').click();
+      cy.contains('Create New Rounding Session').should('be.visible');
+
+      cy.contains('Cancel').click();
+      cy.contains('Create New Rounding Session').should('not.exist');
+    });
+
+    it('should have Create Session button disabled without floor selection', () => {
+      cy.contains('New Session').click();
+
+      // Create Session button should be disabled initially (no floor selected)
+      cy.get('button').contains('Create Session').should('be.disabled');
+    });
+  });
+
+  describe('Session Cards', () => {
+    it('should display session cards when sessions exist', () => {
+      // Wait for content to load
+      cy.wait(1000);
+
+      // Check if sessions exist or no sessions message is shown
+      cy.get('body').then(($body) => {
+        if ($body.find('[class*="grid"]').length > 0) {
+          // Sessions may or may not exist
+          cy.log('Session grid found');
+        } else {
+          cy.contains('No rounding sessions found').should('be.visible');
+        }
+      });
+    });
+  });
+});

--- a/apps/frontend/cypress/e2e/vital-signs/vital-signs-recording.cy.ts
+++ b/apps/frontend/cypress/e2e/vital-signs/vital-signs-recording.cy.ts
@@ -1,0 +1,165 @@
+/// <reference types="cypress" />
+
+/**
+ * Vital Signs Recording E2E Tests
+ *
+ * Tests the vital signs recording functionality for admitted patients.
+ * The vital signs form is accessible from the patient detail page
+ * when the patient has an active admission.
+ */
+describe('Vital Signs Recording', () => {
+  beforeEach(() => {
+    cy.fixture('users').then((users) => {
+      cy.login(users.nurse.username, users.nurse.password);
+    });
+  });
+
+  describe('Vital Signs Form Access', () => {
+    it('should show Record Vitals button for admitted patients', () => {
+      cy.visit('/patients');
+
+      // Wait for patient list to load
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+
+      // Navigate to first patient
+      cy.get('table tbody tr').first().contains('View').click();
+
+      // Check if patient has active admission (will show Record Vitals button)
+      cy.get('body').then(($body) => {
+        if ($body.find('button:contains("Record Vitals")').length > 0) {
+          cy.contains('Record Vitals').should('be.visible');
+        } else {
+          // Patient not admitted - New Admission button should be visible
+          cy.contains('New Admission').should('be.visible');
+        }
+      });
+    });
+  });
+
+  describe('Vital Signs Form', () => {
+    it('should display vital signs form when Record Vitals is clicked', () => {
+      cy.visit('/patients');
+
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+
+      cy.get('body').then(($body) => {
+        if ($body.find('button:contains("Record Vitals")').length > 0) {
+          cy.contains('Record Vitals').click();
+
+          // Form should be visible
+          cy.contains('Record Vital Signs').should('be.visible');
+
+          // Check form fields
+          cy.contains('Temperature').should('be.visible');
+          cy.contains('Blood Pressure').should('be.visible');
+          cy.contains('Pulse').should('be.visible');
+          cy.contains('Respiratory Rate').should('be.visible');
+          cy.contains('SpO2').should('be.visible');
+        }
+      });
+    });
+
+    it('should toggle vital signs form visibility', () => {
+      cy.visit('/patients');
+
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+
+      cy.get('body').then(($body) => {
+        if ($body.find('button:contains("Record Vitals")').length > 0) {
+          // Show form
+          cy.contains('Record Vitals').click();
+          cy.contains('Record Vital Signs').should('be.visible');
+
+          // Hide form
+          cy.contains('Hide Vital Form').click();
+          cy.contains('Record Vital Signs').should('not.exist');
+        }
+      });
+    });
+  });
+
+  describe('Form Validation', () => {
+    it('should validate temperature range', () => {
+      cy.visit('/patients');
+
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+
+      cy.get('body').then(($body) => {
+        if ($body.find('button:contains("Record Vitals")').length > 0) {
+          cy.contains('Record Vitals').click();
+
+          // Enter invalid temperature
+          cy.get('input[placeholder="36.5"]').clear().type('50');
+
+          // Try to submit
+          cy.contains('button', 'Record Vital Signs').click();
+
+          // Should show validation error or warning
+          cy.wait(500);
+        }
+      });
+    });
+  });
+
+  describe('Abnormal Value Alerts', () => {
+    it('should show warning dialog for abnormal values', () => {
+      cy.visit('/patients');
+
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+
+      cy.get('body').then(($body) => {
+        if ($body.find('button:contains("Record Vitals")').length > 0) {
+          cy.contains('Record Vitals').click();
+
+          // Enter abnormal values (high fever)
+          cy.get('input[placeholder="36.5"]').clear().type('39.5');
+
+          // Enter low oxygen saturation
+          cy.get('input[placeholder="98"]').clear().type('88');
+
+          // Submit form
+          cy.contains('button', 'Record Vital Signs').click();
+
+          // Warning dialog should appear
+          cy.get('body').then(($innerBody) => {
+            if ($innerBody.find(':contains("Abnormal Values")').length > 0) {
+              cy.contains('Abnormal Values').should('be.visible');
+              cy.contains('Cancel').should('be.visible');
+              cy.contains('Confirm').should('be.visible');
+            }
+          });
+        }
+      });
+    });
+  });
+
+  describe('Vital Signs Display', () => {
+    it('should display vital trend chart for admitted patients', () => {
+      cy.visit('/patients');
+
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+
+      cy.get('body').then(($body) => {
+        // If patient is admitted, vital signs section should be visible
+        if ($body.find(':contains("Vital Signs")').length > 0) {
+          cy.contains('Vital Signs').should('be.visible');
+        }
+      });
+    });
+
+    it('should display vital alerts for admitted patients', () => {
+      cy.visit('/patients');
+
+      cy.get('table tbody tr', { timeout: 10000 }).should('exist');
+      cy.get('table tbody tr').first().contains('View').click();
+
+      // Check if alerts component exists (for admitted patients)
+      cy.wait(1000); // Wait for data to load
+    });
+  });
+});

--- a/apps/frontend/cypress/fixtures/users.json
+++ b/apps/frontend/cypress/fixtures/users.json
@@ -26,5 +26,19 @@
   "invalid": {
     "username": "invalid_user",
     "password": "wrongpassword"
+  },
+  "testPatients": {
+    "john": {
+      "patientNumber": "P2025000001",
+      "name": "John Doe"
+    },
+    "jane": {
+      "patientNumber": "P2025000002",
+      "name": "Jane Smith"
+    },
+    "mike": {
+      "patientNumber": "P2025000003",
+      "name": "Mike Johnson"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add patient list and detail page E2E tests
- Add vital signs recording flow E2E tests
- Add rounding sessions and detail page E2E tests
- Add room status page E2E tests
- Add role-based access control E2E tests
- Update fixtures with test patient data

Closes #36

## Test Plan
- [ ] Run `pnpm cypress:open` in frontend to verify tests execute correctly
- [ ] Verify patient list tests with search and filter functionality
- [ ] Verify patient detail page navigation and display
- [ ] Verify vital signs recording form (for admitted patients)
- [ ] Verify rounding sessions page and create dialog
- [ ] Verify role-based access control for different user types
- [ ] Verify unauthenticated access redirects to login

## Files Added
- `cypress/e2e/patients/patient-list.cy.ts`
- `cypress/e2e/patients/patient-detail.cy.ts`
- `cypress/e2e/vital-signs/vital-signs-recording.cy.ts`
- `cypress/e2e/rounding/rounding-sessions.cy.ts`
- `cypress/e2e/rounding/rounding-detail.cy.ts`
- `cypress/e2e/rooms/room-status.cy.ts`
- `cypress/e2e/auth/role-based-access.cy.ts`