### PR TITLE
test(report): add unit tests for nursing note service

### DIFF
--- a/apps/backend/src/modules/report/__tests__/nursing-note.service.spec.ts
+++ b/apps/backend/src/modules/report/__tests__/nursing-note.service.spec.ts
@@ -1,0 +1,536 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdmissionStatus, NoteType } from '@prisma/client';
+import { NursingNoteService } from '../nursing-note.service';
+import { NursingNoteRepository } from '../nursing-note.repository';
+import { PrismaService } from '../../../prisma';
+import {
+  createTestNursingNote,
+  createProgressNote,
+  createAssessmentNote,
+  createSignificantNote,
+  createHandoffNote,
+  createTestAdmission,
+} from '../../../../test/factories';
+import { createMockPrismaService } from '../../../../test/utils';
+import { AdmissionNotFoundException, AdmissionNotActiveException } from '../exceptions';
+
+describe('NursingNoteService', () => {
+  let service: NursingNoteService;
+  let noteRepo: jest.Mocked<NursingNoteRepository>;
+  let prismaService: ReturnType<typeof createMockPrismaService>;
+
+  const mockNoteRepo = {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByAdmission: jest.fn(),
+    findSignificant: jest.fn(),
+    findLatest: jest.fn(),
+    countByAdmission: jest.fn(),
+    countSignificantToday: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    prismaService = createMockPrismaService();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NursingNoteService,
+        { provide: NursingNoteRepository, useValue: mockNoteRepo },
+        { provide: PrismaService, useValue: prismaService },
+      ],
+    }).compile();
+
+    service = module.get<NursingNoteService>(NursingNoteService);
+    noteRepo = module.get(NursingNoteRepository);
+
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const admissionId = 'admission-id';
+    const userId = 'user-id';
+    const dto = {
+      noteType: NoteType.PROGRESS,
+      subjective: 'Patient reports mild headache',
+      objective: 'Vital signs stable, patient appears comfortable',
+      assessment: 'Mild tension headache, likely due to stress',
+      plan: 'Continue monitoring, administer PRN analgesic if needed',
+      isSignificant: false,
+    };
+
+    it('should create nursing note successfully', async () => {
+      const admission = createTestAdmission({
+        id: admissionId,
+        status: 'ACTIVE' as AdmissionStatus,
+      });
+      const note = createProgressNote(admissionId, {
+        recordedBy: userId,
+      });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.create.mockResolvedValue(note);
+
+      const result = await service.create(admissionId, dto, userId);
+
+      expect(result.admissionId).toBe(admissionId);
+      expect(result.noteType).toBe(NoteType.PROGRESS);
+      expect(mockNoteRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          admissionId,
+          noteType: dto.noteType,
+          subjective: dto.subjective,
+          objective: dto.objective,
+          assessment: dto.assessment,
+          plan: dto.plan,
+          recordedBy: userId,
+          isSignificant: dto.isSignificant,
+        }),
+      );
+    });
+
+    it('should throw when admission not found', async () => {
+      prismaService.admission.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(admissionId, dto, userId)).rejects.toThrow(
+        AdmissionNotFoundException,
+      );
+    });
+
+    it('should throw when admission not active', async () => {
+      const dischargedAdmission = createTestAdmission({
+        id: admissionId,
+        status: 'DISCHARGED' as AdmissionStatus,
+      });
+      prismaService.admission.findUnique.mockResolvedValue(dischargedAdmission);
+
+      await expect(service.create(admissionId, dto, userId)).rejects.toThrow(
+        AdmissionNotActiveException,
+      );
+    });
+
+    it('should create note with minimal SOAP fields', async () => {
+      const admission = createTestAdmission({
+        id: admissionId,
+        status: 'ACTIVE' as AdmissionStatus,
+      });
+      const minimalDto = {
+        noteType: NoteType.ASSESSMENT,
+        isSignificant: false,
+      };
+      const note = createAssessmentNote(admissionId, {
+        subjective: null,
+        objective: null,
+        assessment: null,
+        plan: null,
+      });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.create.mockResolvedValue(note);
+
+      const result = await service.create(admissionId, minimalDto, userId);
+
+      expect(result.noteType).toBe(NoteType.ASSESSMENT);
+    });
+
+    it('should create significant note', async () => {
+      const admission = createTestAdmission({
+        id: admissionId,
+        status: 'ACTIVE' as AdmissionStatus,
+      });
+      const significantDto = {
+        noteType: NoteType.INCIDENT,
+        subjective: 'Patient reports sudden onset of chest pain',
+        objective: 'Patient diaphoretic, BP elevated',
+        assessment: 'Possible cardiac event',
+        plan: 'Notify physician stat',
+        isSignificant: true,
+      };
+      const note = createSignificantNote(admissionId);
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.create.mockResolvedValue(note);
+
+      const result = await service.create(admissionId, significantDto, userId);
+
+      expect(result.isSignificant).toBe(true);
+      expect(result.noteType).toBe(NoteType.INCIDENT);
+    });
+
+    it('should support all note types', async () => {
+      const admission = createTestAdmission({
+        id: admissionId,
+        status: 'ACTIVE' as AdmissionStatus,
+      });
+
+      const noteTypes = [
+        NoteType.ASSESSMENT,
+        NoteType.PROGRESS,
+        NoteType.PROCEDURE,
+        NoteType.INCIDENT,
+        NoteType.HANDOFF,
+      ];
+
+      for (const noteType of noteTypes) {
+        const typeDto = {
+          noteType,
+          isSignificant: false,
+        };
+        const note = createTestNursingNote({
+          admissionId,
+          noteType,
+        });
+
+        prismaService.admission.findUnique.mockResolvedValue(admission);
+        mockNoteRepo.create.mockResolvedValue(note);
+
+        const result = await service.create(admissionId, typeDto, userId);
+
+        expect(result.noteType).toBe(noteType);
+      }
+    });
+  });
+
+  describe('getByAdmission', () => {
+    const admissionId = 'admission-id';
+    const dto = {
+      page: 1,
+      limit: 20,
+    };
+
+    it('should return nursing notes with pagination', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const notes = [createProgressNote(admissionId), createAssessmentNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: notes,
+        total: 2,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      const result = await service.getByAdmission(admissionId, dto);
+
+      expect(result.data.length).toBe(2);
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+    });
+
+    it('should filter by note type', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const progressNotes = [createProgressNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: progressNotes,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      await service.getByAdmission(admissionId, {
+        ...dto,
+        noteType: NoteType.PROGRESS,
+      });
+
+      expect(mockNoteRepo.findByAdmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          noteType: NoteType.PROGRESS,
+        }),
+      );
+    });
+
+    it('should filter by significant notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const significantNotes = [createSignificantNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: significantNotes,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      await service.getByAdmission(admissionId, {
+        ...dto,
+        isSignificant: true,
+      });
+
+      expect(mockNoteRepo.findByAdmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isSignificant: true,
+        }),
+      );
+    });
+
+    it('should throw when admission not found', async () => {
+      prismaService.admission.findUnique.mockResolvedValue(null);
+
+      await expect(service.getByAdmission(admissionId, dto)).rejects.toThrow(
+        AdmissionNotFoundException,
+      );
+    });
+
+    it('should return empty array when no notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 0,
+      });
+
+      const result = await service.getByAdmission(admissionId, dto);
+
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should handle pagination correctly', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const notes = [createProgressNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: notes,
+        total: 50,
+        page: 3,
+        limit: 10,
+        totalPages: 5,
+      });
+
+      const result = await service.getByAdmission(admissionId, {
+        page: 3,
+        limit: 10,
+      });
+
+      expect(result.page).toBe(3);
+      expect(result.limit).toBe(10);
+      expect(result.totalPages).toBe(5);
+    });
+  });
+
+  describe('getSignificant', () => {
+    const admissionId = 'admission-id';
+
+    it('should return significant notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const significantNotes = [createSignificantNote(admissionId), createHandoffNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findSignificant.mockResolvedValue(significantNotes);
+
+      const result = await service.getSignificant(admissionId);
+
+      expect(result.length).toBe(2);
+      expect(result.every((note) => note.isSignificant)).toBe(true);
+    });
+
+    it('should return empty array when no significant notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findSignificant.mockResolvedValue([]);
+
+      const result = await service.getSignificant(admissionId);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should throw when admission not found', async () => {
+      prismaService.admission.findUnique.mockResolvedValue(null);
+
+      await expect(service.getSignificant(admissionId)).rejects.toThrow(AdmissionNotFoundException);
+    });
+  });
+
+  describe('getLatest', () => {
+    const admissionId = 'admission-id';
+
+    it('should return latest nursing note', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const note = createProgressNote(admissionId);
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findLatest.mockResolvedValue(note);
+
+      const result = await service.getLatest(admissionId);
+
+      expect(result).not.toBeNull();
+      expect(result!.admissionId).toBe(admissionId);
+    });
+
+    it('should return null when no notes exist', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findLatest.mockResolvedValue(null);
+
+      const result = await service.getLatest(admissionId);
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw when admission not found', async () => {
+      prismaService.admission.findUnique.mockResolvedValue(null);
+
+      await expect(service.getLatest(admissionId)).rejects.toThrow(AdmissionNotFoundException);
+    });
+  });
+
+  describe('SOAP format validation', () => {
+    const admissionId = 'admission-id';
+    const userId = 'user-id';
+
+    it('should preserve all SOAP components', async () => {
+      const admission = createTestAdmission({
+        id: admissionId,
+        status: 'ACTIVE' as AdmissionStatus,
+      });
+      const soapNote = {
+        noteType: NoteType.PROGRESS,
+        subjective: 'S: Patient states feeling much better',
+        objective: 'O: Afebrile, lungs clear bilateral',
+        assessment: 'A: Condition improving, infection resolving',
+        plan: 'P: Continue antibiotics, discharge tomorrow',
+        isSignificant: false,
+      };
+      const createdNote = createProgressNote(admissionId, {
+        subjective: soapNote.subjective,
+        objective: soapNote.objective,
+        assessment: soapNote.assessment,
+        plan: soapNote.plan,
+      });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.create.mockResolvedValue(createdNote);
+
+      const result = await service.create(admissionId, soapNote, userId);
+
+      expect(result.subjective).toBe(soapNote.subjective);
+      expect(result.objective).toBe(soapNote.objective);
+      expect(result.assessment).toBe(soapNote.assessment);
+      expect(result.plan).toBe(soapNote.plan);
+    });
+
+    it('should allow partial SOAP entries', async () => {
+      const admission = createTestAdmission({
+        id: admissionId,
+        status: 'ACTIVE' as AdmissionStatus,
+      });
+      const partialSoapNote = {
+        noteType: NoteType.ASSESSMENT,
+        subjective: 'Patient reports no complaints',
+        objective: 'All systems within normal limits',
+        isSignificant: false,
+      };
+      const createdNote = createAssessmentNote(admissionId, {
+        subjective: partialSoapNote.subjective,
+        objective: partialSoapNote.objective,
+        assessment: null,
+        plan: null,
+      });
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.create.mockResolvedValue(createdNote);
+
+      const result = await service.create(admissionId, partialSoapNote, userId);
+
+      expect(result.subjective).toBe(partialSoapNote.subjective);
+      expect(result.objective).toBe(partialSoapNote.objective);
+      expect(result.assessment).toBeNull();
+      expect(result.plan).toBeNull();
+    });
+  });
+
+  describe('note types', () => {
+    const admissionId = 'admission-id';
+
+    it('should handle ASSESSMENT notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const assessmentNotes = [createAssessmentNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: assessmentNotes,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      const result = await service.getByAdmission(admissionId, {
+        noteType: NoteType.ASSESSMENT,
+      });
+
+      expect(result.data[0].noteType).toBe(NoteType.ASSESSMENT);
+    });
+
+    it('should handle PROGRESS notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const progressNotes = [createProgressNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: progressNotes,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      const result = await service.getByAdmission(admissionId, {
+        noteType: NoteType.PROGRESS,
+      });
+
+      expect(result.data[0].noteType).toBe(NoteType.PROGRESS);
+    });
+
+    it('should handle INCIDENT notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const incidentNotes = [createSignificantNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: incidentNotes,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      const result = await service.getByAdmission(admissionId, {
+        noteType: NoteType.INCIDENT,
+      });
+
+      expect(result.data[0].noteType).toBe(NoteType.INCIDENT);
+    });
+
+    it('should handle HANDOFF notes', async () => {
+      const admission = createTestAdmission({ id: admissionId });
+      const handoffNotes = [createHandoffNote(admissionId)];
+
+      prismaService.admission.findUnique.mockResolvedValue(admission);
+      mockNoteRepo.findByAdmission.mockResolvedValue({
+        data: handoffNotes,
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      });
+
+      const result = await service.getByAdmission(admissionId, {
+        noteType: NoteType.HANDOFF,
+      });
+
+      expect(result.data[0].noteType).toBe(NoteType.HANDOFF);
+    });
+  });
+});

--- a/apps/backend/test/factories/index.ts
+++ b/apps/backend/test/factories/index.ts
@@ -5,3 +5,4 @@ export * from './room.factory';
 export * from './vital-sign.factory';
 export * from './intake-output.factory';
 export * from './medication.factory';
+export * from './nursing-note.factory';

--- a/apps/backend/test/factories/nursing-note.factory.ts
+++ b/apps/backend/test/factories/nursing-note.factory.ts
@@ -1,0 +1,107 @@
+import { faker } from '@faker-js/faker';
+import { NursingNote, NoteType } from '@prisma/client';
+
+export function createTestNursingNote(overrides?: Partial<NursingNote>): NursingNote {
+  const now = new Date();
+  return {
+    id: faker.string.uuid(),
+    admissionId: faker.string.uuid(),
+    noteType: faker.helpers.arrayElement([
+      'ASSESSMENT',
+      'PROGRESS',
+      'PROCEDURE',
+      'INCIDENT',
+      'HANDOFF',
+    ] as NoteType[]),
+    subjective: faker.lorem.sentence(),
+    objective: faker.lorem.sentence(),
+    assessment: faker.lorem.sentence(),
+    plan: faker.lorem.sentence(),
+    recordedAt: now,
+    recordedBy: faker.string.uuid(),
+    isSignificant: faker.datatype.boolean(),
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+export function createProgressNote(
+  admissionId: string,
+  overrides?: Partial<NursingNote>,
+): NursingNote {
+  return createTestNursingNote({
+    admissionId,
+    noteType: 'PROGRESS' as NoteType,
+    subjective: 'Patient reports feeling better today',
+    objective: 'Vital signs stable, patient ambulating without assistance',
+    assessment: 'Condition improving, pain well controlled',
+    plan: 'Continue current treatment plan, monitor for changes',
+    isSignificant: false,
+    ...overrides,
+  });
+}
+
+export function createAssessmentNote(
+  admissionId: string,
+  overrides?: Partial<NursingNote>,
+): NursingNote {
+  return createTestNursingNote({
+    admissionId,
+    noteType: 'ASSESSMENT' as NoteType,
+    subjective: 'Patient reports mild discomfort',
+    objective: 'Alert and oriented, skin warm and dry',
+    assessment: 'Initial nursing assessment completed',
+    plan: 'Implement care plan as ordered',
+    isSignificant: false,
+    ...overrides,
+  });
+}
+
+export function createSignificantNote(
+  admissionId: string,
+  overrides?: Partial<NursingNote>,
+): NursingNote {
+  return createTestNursingNote({
+    admissionId,
+    noteType: 'INCIDENT' as NoteType,
+    subjective: 'Patient reports sudden onset of chest pain',
+    objective: 'Patient diaphoretic, BP elevated at 180/100',
+    assessment: 'Possible cardiac event, requires immediate attention',
+    plan: 'Notify physician stat, prepare for EKG, start O2 as needed',
+    isSignificant: true,
+    ...overrides,
+  });
+}
+
+export function createHandoffNote(
+  admissionId: string,
+  overrides?: Partial<NursingNote>,
+): NursingNote {
+  return createTestNursingNote({
+    admissionId,
+    noteType: 'HANDOFF' as NoteType,
+    subjective: 'Patient had uneventful shift, no complaints',
+    objective: 'All vital signs within normal limits throughout shift',
+    assessment: 'Stable condition, ready for continued monitoring',
+    plan: 'Continue current plan, follow up on pending lab results',
+    isSignificant: true,
+    ...overrides,
+  });
+}
+
+export function createProcedureNote(
+  admissionId: string,
+  overrides?: Partial<NursingNote>,
+): NursingNote {
+  return createTestNursingNote({
+    admissionId,
+    noteType: 'PROCEDURE' as NoteType,
+    subjective: 'Patient expressed understanding of procedure',
+    objective: 'Procedure completed without complications',
+    assessment: 'Patient tolerated procedure well',
+    plan: 'Monitor for post-procedure complications',
+    isSignificant: false,
+    ...overrides,
+  });
+}


### PR DESCRIPTION
Closes #77

## Summary
- Add comprehensive unit tests for NursingNoteService
- Create nursing-note.factory.ts with 6 helper functions for test data generation
- All 24 test cases pass, covering SOAP format validation, note types, and filtering

## Changes Made
- `apps/backend/src/modules/report/__tests__/nursing-note.service.spec.ts` - 24 test cases
- `apps/backend/test/factories/nursing-note.factory.ts` - Test data factory
- `apps/backend/test/factories/index.ts` - Export nursing-note factory

## Test Coverage
- `create()`: Note creation, admission validation, SOAP format, all note types
- `getByAdmission()`: Pagination, note type filtering, significant note filtering
- `getSignificant()`: Significant notes retrieval
- `getLatest()`: Latest note retrieval
- SOAP format validation tests
- Note type-specific tests (ASSESSMENT, PROGRESS, PROCEDURE, INCIDENT, HANDOFF)

## Test Plan
- [x] All 24 nursing-note.service.spec.ts tests pass
- [x] All 359 existing tests pass (no regressions)
- [x] Build succeeds