### PR TITLE
feat(backend): add grafana performance monitoring dashboard

### DIFF
--- a/apps/backend/k6/README.md
+++ b/apps/backend/k6/README.md
@@ -168,6 +168,30 @@ Ensure the backend server is running:
 npm run dev
 ```
 
+## Grafana Monitoring Dashboard
+
+For real-time visualization of test results, use the Grafana monitoring setup:
+
+```bash
+# Start monitoring services (InfluxDB + Grafana)
+npm run monitoring:up
+
+# Run tests with InfluxDB output
+npm run test:perf:monitor         # Smoke test
+npm run test:perf:monitor:normal  # Normal load
+npm run test:perf:monitor:peak    # Peak load
+npm run test:perf:ws:monitor      # WebSocket tests
+npm run test:perf:db:monitor      # Database tests
+
+# Access Grafana at http://localhost:3002
+# Dashboard: "Hospital ERP - k6 Performance Dashboard"
+
+# Stop monitoring services
+npm run monitoring:down
+```
+
+See `monitoring/README.md` for detailed setup instructions.
+
 ## CI/CD Integration
 
 See `.github/workflows/performance.yml` for GitHub Actions integration (to be added in issue #104).

--- a/apps/backend/monitoring/README.md
+++ b/apps/backend/monitoring/README.md
@@ -1,0 +1,167 @@
+# Performance Monitoring Setup
+
+Grafana-based performance monitoring dashboard for k6 load testing results.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Hospital ERP main services running (`docker-compose up`)
+
+## Quick Start
+
+### 1. Start Monitoring Services
+
+```bash
+cd apps/backend/monitoring
+docker compose -f docker-compose.monitoring.yml up -d
+```
+
+### 2. Run k6 Tests with InfluxDB Output
+
+```bash
+# From apps/backend directory
+k6 run --out influxdb=http://localhost:8086/k6 k6/api-load-test.js
+
+# Or with specific scenario
+k6 run --out influxdb=http://localhost:8086/k6 -e SCENARIO=normalLoad k6/api-load-test.js
+```
+
+### 3. Access Grafana Dashboard
+
+- URL: http://localhost:3002
+- Default credentials: admin / admin
+- Dashboard: "Hospital ERP - k6 Performance Dashboard"
+
+## Architecture
+
+```
+                    +------------+
+                    |   k6       |
+                    +-----+------+
+                          |
+                          | InfluxDB Line Protocol
+                          v
+                    +------------+
+                    | InfluxDB   | (Port 8086)
+                    +-----+------+
+                          |
+                          | Query
+                          v
+                    +------------+
+                    |  Grafana   | (Port 3002)
+                    +------------+
+```
+
+## Services
+
+| Service  | Port | Description                    |
+| -------- | ---- | ------------------------------ |
+| InfluxDB | 8086 | Time-series database for k6    |
+| Grafana  | 3002 | Visualization and dashboarding |
+
+## Dashboard Panels
+
+### Overview Section
+
+- Average Response Time
+- P95 Response Time (SDS Target: < 500ms)
+- Error Rate (SDS Target: < 1%)
+- Requests per Second
+- Maximum Virtual Users
+- Total Requests
+
+### Response Times Section
+
+- HTTP Response Time percentiles (mean, p90, p95, p99)
+- Virtual Users and Throughput over time
+
+### Custom Metrics Section
+
+- API Endpoint Response Times (Login, Patient List, Room Dashboard)
+- WebSocket Performance (Connection, Subscribe, Message Latency)
+
+### Database Performance Section
+
+- Database Query Response Times (Patient Search, Patient List, Room Dashboard, Admission List)
+
+## Running All Test Scenarios
+
+```bash
+# Smoke test (quick validation)
+k6 run --out influxdb=http://localhost:8086/k6 k6/api-load-test.js
+
+# Normal load (50 VUs, 5 min)
+k6 run --out influxdb=http://localhost:8086/k6 -e SCENARIO=normalLoad k6/api-load-test.js
+
+# Peak load (ramp to 100 VUs)
+k6 run --out influxdb=http://localhost:8086/k6 -e SCENARIO=peakLoad k6/api-load-test.js
+
+# WebSocket tests
+k6 run --out influxdb=http://localhost:8086/k6 k6/websocket-test.js
+
+# Database query tests
+k6 run --out influxdb=http://localhost:8086/k6 k6/db-query-test.js
+```
+
+## NPM Scripts
+
+Add these scripts to run tests with monitoring:
+
+```bash
+# Run from apps/backend directory
+npm run test:perf:monitor      # API tests with InfluxDB output
+npm run test:perf:ws:monitor   # WebSocket tests with InfluxDB output
+npm run test:perf:db:monitor   # DB tests with InfluxDB output
+```
+
+## Cleanup
+
+```bash
+# Stop monitoring services
+docker compose -f docker-compose.monitoring.yml down
+
+# Remove data volumes (reset)
+docker compose -f docker-compose.monitoring.yml down -v
+```
+
+## Troubleshooting
+
+### InfluxDB Connection Error
+
+Ensure InfluxDB is running and accessible:
+
+```bash
+curl http://localhost:8086/ping
+```
+
+### No Data in Grafana
+
+1. Verify k6 is outputting to InfluxDB:
+
+   ```bash
+   k6 run --out influxdb=http://localhost:8086/k6 k6/api-load-test.js
+   ```
+
+2. Check InfluxDB has data:
+   ```bash
+   curl -G 'http://localhost:8086/query' --data-urlencode 'db=k6' --data-urlencode 'q=SHOW MEASUREMENTS'
+   ```
+
+### Network Issues
+
+If using Docker network, ensure k6 can reach InfluxDB:
+
+```bash
+# Use Docker network name
+k6 run --out influxdb=http://hospital-erp-influxdb:8086/k6 k6/api-load-test.js
+```
+
+## Performance Targets (SDS Reference)
+
+| Metric              | Target        | Dashboard Panel       |
+| ------------------- | ------------- | --------------------- |
+| API Response Time   | < 500ms (p95) | P95 Response Time     |
+| Database Query Time | < 100ms (p95) | Database Query Times  |
+| WebSocket Latency   | < 3 seconds   | WebSocket Performance |
+| Error Rate          | < 1%          | Error Rate            |
+| Concurrent Users    | 100+          | Max VUs               |

--- a/apps/backend/monitoring/docker-compose.monitoring.yml
+++ b/apps/backend/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,55 @@
+version: '3.8'
+
+services:
+  # InfluxDB for k6 metrics storage
+  influxdb:
+    image: influxdb:1.8-alpine
+    container_name: hospital-erp-influxdb
+    restart: unless-stopped
+    ports:
+      - '8086:8086'
+    environment:
+      INFLUXDB_DB: k6
+      INFLUXDB_HTTP_AUTH_ENABLED: 'false'
+    volumes:
+      - influxdb_data:/var/lib/influxdb
+    healthcheck:
+      test: ['CMD', 'influx', '-execute', 'SHOW DATABASES']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - hospital-network
+
+  # Grafana for visualization
+  grafana:
+    image: grafana/grafana:11.0.0
+    container_name: hospital-erp-grafana
+    restart: unless-stopped
+    ports:
+      - '3002:3000'
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Viewer
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    networks:
+      - hospital-network
+
+networks:
+  hospital-network:
+    external: true
+    name: hospital_erp_system_hospital-network
+
+volumes:
+  influxdb_data:
+  grafana_data:

--- a/apps/backend/monitoring/grafana/dashboards/k6-performance.json
+++ b/apps/backend/monitoring/grafana/dashboards/k6-performance.json
@@ -1,0 +1,713 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Hospital ERP System Performance Dashboard - k6 Load Testing Results",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["mean"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "query": "SELECT mean(\"value\") FROM \"http_req_duration\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Avg Response Time",
+      "type": "stat"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 400 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "query": "SELECT percentile(\"value\", 95) FROM \"http_req_duration\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "P95 Response Time",
+      "type": "stat"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["mean"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "query": "SELECT mean(\"value\") FROM \"http_req_failed\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["mean"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "query": "SELECT count(\"value\") / 60 FROM \"http_reqs\" WHERE $timeFilter GROUP BY time(1m)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Requests/sec",
+      "type": "stat"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 1 },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["max"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "query": "SELECT max(\"value\") FROM \"vus\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Max VUs",
+      "type": "stat"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 1 },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["sum"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "query": "SELECT count(\"value\") FROM \"http_reqs\" WHERE $timeFilter",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Total Requests",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "id": 101,
+      "panels": [],
+      "title": "Response Times",
+      "type": "row"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "alias": "Mean",
+          "query": "SELECT mean(\"value\") FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "P90",
+          "query": "SELECT percentile(\"value\", 90) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "P95",
+          "query": "SELECT percentile(\"value\", 95) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "P99",
+          "query": "SELECT percentile(\"value\", 99) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "HTTP Response Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "alias": "Virtual Users",
+          "query": "SELECT mean(\"value\") FROM \"vus\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Requests/s",
+          "query": "SELECT count(\"value\") FROM \"http_reqs\" WHERE $timeFilter GROUP BY time($__interval) / ($__interval_ms / 1000)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Virtual Users & Throughput",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "id": 102,
+      "panels": [],
+      "title": "Custom Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "alias": "Login",
+          "query": "SELECT mean(\"value\") FROM \"login_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Patient List",
+          "query": "SELECT mean(\"value\") FROM \"patient_list_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Room Dashboard",
+          "query": "SELECT mean(\"value\") FROM \"room_dashboard_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "API Endpoint Response Times",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 3000 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "alias": "WS Connection",
+          "query": "SELECT mean(\"value\") FROM \"ws_connection_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "WS Subscribe",
+          "query": "SELECT mean(\"value\") FROM \"ws_subscribe_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "WS Message Latency",
+          "query": "SELECT mean(\"value\") FROM \"ws_message_latency\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "WebSocket Performance",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 103,
+      "panels": [],
+      "title": "Database Performance",
+      "type": "row"
+    },
+    {
+      "datasource": "InfluxDB-k6",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 100 }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "alias": "Patient Search",
+          "query": "SELECT mean(\"value\") FROM \"db_patient_search_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Patient List",
+          "query": "SELECT mean(\"value\") FROM \"db_patient_list_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Room Dashboard",
+          "query": "SELECT mean(\"value\") FROM \"db_room_dashboard_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "C",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "Admission List",
+          "query": "SELECT mean(\"value\") FROM \"db_admission_list_duration\" WHERE $timeFilter GROUP BY time($__interval)",
+          "rawQuery": true,
+          "refId": "D",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Database Query Response Times",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["k6", "performance", "hospital-erp"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "browser",
+  "title": "Hospital ERP - k6 Performance Dashboard",
+  "uid": "hospital-erp-k6-perf",
+  "version": 1,
+  "weekStart": ""
+}

--- a/apps/backend/monitoring/grafana/provisioning/dashboards/default.yml
+++ b/apps/backend/monitoring/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'Hospital ERP Performance Dashboards'
+    orgId: 1
+    folder: 'k6 Performance'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/apps/backend/monitoring/grafana/provisioning/datasources/influxdb.yml
+++ b/apps/backend/monitoring/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB-k6
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    database: k6
+    isDefault: true
+    editable: false

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,7 +30,14 @@
     "test:perf:db": "k6 run k6/db-query-test.js",
     "test:perf:normal": "k6 run -e SCENARIO=normalLoad k6/api-load-test.js",
     "test:perf:peak": "k6 run -e SCENARIO=peakLoad k6/api-load-test.js",
-    "test:perf:stress": "k6 run -e SCENARIO=stressTest k6/api-load-test.js"
+    "test:perf:stress": "k6 run -e SCENARIO=stressTest k6/api-load-test.js",
+    "test:perf:monitor": "k6 run --out influxdb=http://localhost:8086/k6 k6/api-load-test.js",
+    "test:perf:monitor:normal": "k6 run --out influxdb=http://localhost:8086/k6 -e SCENARIO=normalLoad k6/api-load-test.js",
+    "test:perf:monitor:peak": "k6 run --out influxdb=http://localhost:8086/k6 -e SCENARIO=peakLoad k6/api-load-test.js",
+    "test:perf:ws:monitor": "k6 run --out influxdb=http://localhost:8086/k6 k6/websocket-test.js",
+    "test:perf:db:monitor": "k6 run --out influxdb=http://localhost:8086/k6 k6/db-query-test.js",
+    "monitoring:up": "docker compose -f monitoring/docker-compose.monitoring.yml up -d",
+    "monitoring:down": "docker compose -f monitoring/docker-compose.monitoring.yml down"
   },
   "dependencies": {
     "@nestjs-modules/ioredis": "^2.0.2",


### PR DESCRIPTION
Closes #111

## Summary
- Add Grafana-based monitoring setup for k6 performance test visualization
- Add docker-compose.monitoring.yml with InfluxDB and Grafana services
- Add pre-configured performance dashboard with response time, error rate, and throughput metrics
- Add npm scripts for test execution with InfluxDB output (`test:perf:monitor`, `monitoring:up/down`)

## Changes Made
- `apps/backend/monitoring/docker-compose.monitoring.yml`: InfluxDB + Grafana services
- `apps/backend/monitoring/grafana/dashboards/k6-performance.json`: Pre-configured dashboard
- `apps/backend/monitoring/grafana/provisioning/`: Data source and dashboard provisioning
- `apps/backend/monitoring/README.md`: Setup and usage documentation
- `apps/backend/package.json`: New npm scripts for monitoring
- `apps/backend/k6/README.md`: Added monitoring integration section

## Test Plan
- [ ] Run `npm run monitoring:up` to start InfluxDB and Grafana
- [ ] Access Grafana at http://localhost:3002 (admin/admin)
- [ ] Run `npm run test:perf:monitor` to execute tests with InfluxDB output
- [ ] Verify dashboard displays metrics correctly
- [ ] Run `npm run monitoring:down` to clean up