### PR TITLE
feat(infra): add kubernetes base manifests structure with kustomize

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,116 @@
+# Kubernetes Manifests
+
+This directory contains Kubernetes manifests for the Hospital ERP System using Kustomize for environment-specific configurations.
+
+## Directory Structure
+
+```
+k8s/
+├── base/                          # Base configurations (shared across all environments)
+│   ├── kustomization.yaml         # Base kustomization file
+│   ├── namespace.yaml             # Namespace definition
+│   ├── backend/                   # Backend (NestJS) deployment and service
+│   │   ├── deployment.yaml
+│   │   └── service.yaml
+│   ├── frontend/                  # Frontend (Next.js) deployment and service
+│   │   ├── deployment.yaml
+│   │   └── service.yaml
+│   ├── database/                  # PostgreSQL manifests (TODO)
+│   ├── cache/                     # Redis manifests (TODO)
+│   ├── ingress/                   # Ingress controller configuration (TODO)
+│   ├── configmaps/                # ConfigMaps for application configuration (TODO)
+│   ├── secrets/                   # External Secrets configuration (TODO)
+│   ├── network-policies/          # Network policies for security (TODO)
+│   ├── rbac/                      # RBAC and service accounts (TODO)
+│   └── pdb/                       # Pod Disruption Budgets (TODO)
+├── overlays/                      # Environment-specific configurations
+│   ├── development/               # Development environment
+│   │   └── kustomization.yaml
+│   ├── staging/                   # Staging environment
+│   │   └── kustomization.yaml
+│   └── production/                # Production environment
+│       └── kustomization.yaml
+└── monitoring/                    # Monitoring stack (Prometheus, Grafana, Loki)
+```
+
+## Usage
+
+### Preview manifests
+
+```bash
+# Base configuration
+kubectl kustomize k8s/base
+
+# Development environment
+kubectl kustomize k8s/overlays/development
+
+# Staging environment
+kubectl kustomize k8s/overlays/staging
+
+# Production environment
+kubectl kustomize k8s/overlays/production
+```
+
+### Apply manifests
+
+```bash
+# Apply to development environment
+kubectl apply -k k8s/overlays/development
+
+# Apply to staging environment
+kubectl apply -k k8s/overlays/staging
+
+# Apply to production environment
+kubectl apply -k k8s/overlays/production
+```
+
+### Delete resources
+
+```bash
+kubectl delete -k k8s/overlays/development
+```
+
+## Environment Differences
+
+| Component         | Development      | Staging              | Production        |
+| ----------------- | ---------------- | -------------------- | ----------------- |
+| Namespace         | hospital-erp-dev | hospital-erp-staging | hospital-erp-prod |
+| Backend replicas  | 1                | 2                    | 3                 |
+| Frontend replicas | 1                | 2                    | 3                 |
+| Image tag         | dev              | staging              | stable            |
+
+## Security Features
+
+- Pod Security Standards: `restricted` profile enforced
+- Security contexts configured for all containers:
+  - `runAsNonRoot: true`
+  - `readOnlyRootFilesystem: true`
+  - `allowPrivilegeEscalation: false`
+  - All capabilities dropped
+
+## Labels
+
+All resources include standard Kubernetes recommended labels:
+
+- `app.kubernetes.io/name`: Component name
+- `app.kubernetes.io/component`: Component type (api, web, etc.)
+- `app.kubernetes.io/part-of`: hospital-erp-system
+- `app.kubernetes.io/managed-by`: kustomize
+- `environment`: Environment name (development, staging, production)
+
+## Related Issues
+
+- #117 - Kubernetes Deployment Implementation (Epic)
+- #118 - Kubernetes Base Manifests Structure Setup (This issue)
+- #119 - Backend Deployment and Service Configuration
+- #120 - Frontend Deployment and Service Configuration
+- #121 - Ingress Controller and TLS Configuration
+- #122 - ConfigMaps and External Secrets Setup
+- #123 - Redis Cluster Configuration
+- #124 - Network Policies Implementation
+- #125 - RBAC and Service Accounts Setup
+- #126 - HorizontalPodAutoscaler Configuration
+- #127 - Pod Disruption Budgets Setup
+- #128 - Prometheus and Grafana Monitoring Stack
+- #129 - Loki Logging Stack Setup
+- #130 - Alerting Rules Configuration

--- a/k8s/base/backend/deployment.yaml
+++ b/k8s/base/backend/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: backend
+        app.kubernetes.io/component: api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: backend
+          image: hospital-erp/backend:latest
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          envFrom:
+            - configMapRef:
+                name: backend-config
+            - secretRef:
+                name: backend-secrets

--- a/k8s/base/backend/kustomization.yaml
+++ b/k8s/base/backend/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/backend/service.yaml
+++ b/k8s/base/backend/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: backend

--- a/k8s/base/cache/.gitkeep
+++ b/k8s/base/cache/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for Redis cache manifests
+# See issue #123 for implementation

--- a/k8s/base/configmaps/.gitkeep
+++ b/k8s/base/configmaps/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for ConfigMaps configuration
+# See issue #122 for implementation

--- a/k8s/base/database/.gitkeep
+++ b/k8s/base/database/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for PostgreSQL database manifests
+# See issue #119 for implementation

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: frontend
+        app.kubernetes.io/component: web
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: frontend
+          image: hospital-erp/frontend:latest
+          ports:
+            - name: http
+              containerPort: 3001
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          envFrom:
+            - configMapRef:
+                name: frontend-config

--- a/k8s/base/frontend/kustomization.yaml
+++ b/k8s/base/frontend/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/base/frontend/service.yaml
+++ b/k8s/base/frontend/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3001
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: frontend

--- a/k8s/base/ingress/.gitkeep
+++ b/k8s/base/ingress/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for Ingress controller and TLS configuration
+# See issue #121 for implementation

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hospital-erp-system
+
+resources:
+  - namespace.yaml
+  - backend/deployment.yaml
+  - backend/service.yaml
+  - frontend/deployment.yaml
+  - frontend/service.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: hospital-erp-system
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: true
+    includeTemplates: true
+
+images:
+  - name: hospital-erp/backend
+    newTag: latest
+  - name: hospital-erp/frontend
+    newTag: latest

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hospital-erp-system
+  labels:
+    app.kubernetes.io/name: hospital-erp
+    app.kubernetes.io/part-of: hospital-erp-system
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/k8s/base/network-policies/.gitkeep
+++ b/k8s/base/network-policies/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for Network Policies
+# See issue #124 for implementation

--- a/k8s/base/pdb/.gitkeep
+++ b/k8s/base/pdb/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for Pod Disruption Budgets
+# See issue #127 for implementation

--- a/k8s/base/rbac/.gitkeep
+++ b/k8s/base/rbac/.gitkeep
@@ -1,0 +1,2 @@
+# Placeholder for RBAC and Service Accounts
+# See issue #125 for implementation

--- a/k8s/monitoring/.gitkeep
+++ b/k8s/monitoring/.gitkeep
@@ -1,0 +1,4 @@
+# Placeholder for monitoring stack configuration
+# See issue #128 for Prometheus and Grafana setup
+# See issue #129 for Loki logging stack
+# See issue #130 for alerting rules

--- a/k8s/overlays/development/kustomization.yaml
+++ b/k8s/overlays/development/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hospital-erp-dev
+
+resources:
+  - ../../base
+
+namePrefix: dev-
+
+labels:
+  - pairs:
+      environment: development
+    includeSelectors: true
+    includeTemplates: true
+
+replicas:
+  - name: backend
+    count: 1
+  - name: frontend
+    count: 1
+
+images:
+  - name: hospital-erp/backend
+    newTag: dev
+  - name: hospital-erp/frontend
+    newTag: dev

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hospital-erp-prod
+
+resources:
+  - ../../base
+
+namePrefix: prod-
+
+labels:
+  - pairs:
+      environment: production
+    includeSelectors: true
+    includeTemplates: true
+
+replicas:
+  - name: backend
+    count: 3
+  - name: frontend
+    count: 3
+
+images:
+  - name: hospital-erp/backend
+    newTag: stable
+  - name: hospital-erp/frontend
+    newTag: stable

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: hospital-erp-staging
+
+resources:
+  - ../../base
+
+namePrefix: staging-
+
+labels:
+  - pairs:
+      environment: staging
+    includeSelectors: true
+    includeTemplates: true
+
+replicas:
+  - name: backend
+    count: 2
+  - name: frontend
+    count: 2
+
+images:
+  - name: hospital-erp/backend
+    newTag: staging
+  - name: hospital-erp/frontend
+    newTag: staging


### PR DESCRIPTION
## Summary
- Create foundational Kubernetes manifest structure using Kustomize
- Add base namespace with Pod Security Standards (restricted profile)
- Implement backend and frontend deployment/service manifests
- Configure environment overlays for development, staging, and production
- Add comprehensive documentation for directory structure

## What
This PR establishes the Kubernetes infrastructure foundation for the Hospital ERP System:

### Directory Structure
```
k8s/
├── base/
│   ├── kustomization.yaml
│   ├── namespace.yaml
│   ├── backend/
│   ├── frontend/
│   └── (placeholder directories for future components)
├── overlays/
│   ├── development/
│   ├── staging/
│   └── production/
└── monitoring/
```

### Key Features
- **Pod Security Standards**: Namespace configured with `restricted` enforcement
- **Security Contexts**: All containers run as non-root with read-only filesystem
- **Resource Limits**: CPU and memory constraints defined for all workloads
- **Health Probes**: Liveness and readiness probes configured
- **Environment Overlays**: Different replica counts and image tags per environment

## Why
This is the starting point for Kubernetes deployment (Part of #117). All subsequent infrastructure issues depend on this base structure.

## Test Plan
- [x] `kubectl kustomize k8s/base` runs without errors
- [x] `kubectl kustomize k8s/overlays/development` runs without errors
- [x] `kubectl kustomize k8s/overlays/staging` runs without errors
- [x] `kubectl kustomize k8s/overlays/production` runs without errors

Closes #118