### PR TITLE
feat(k8s): add nginx ingress controller and tls configuration

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -37,6 +37,8 @@ module.exports = {
         'deps',
         'ci',
         'docs',
+        'infra',
+        'k8s',
       ],
     ],
     'subject-case': [2, 'always', 'lower-case'],

--- a/k8s/base/ingress/.gitkeep
+++ b/k8s/base/ingress/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder for Ingress controller and TLS configuration
-# See issue #121 for implementation

--- a/k8s/base/ingress/cluster-issuer.yaml
+++ b/k8s/base/ingress/cluster-issuer.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: cluster-issuer
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: admin@hospital.example.com
+    privateKeySecretRef:
+      name: letsencrypt-staging-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+  labels:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/component: cluster-issuer
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: admin@hospital.example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/k8s/base/ingress/ingress.yaml
+++ b/k8s/base/ingress/ingress.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hospital-erp-ingress
+  labels:
+    app.kubernetes.io/name: hospital-erp-ingress
+    app.kubernetes.io/component: ingress
+  annotations:
+    # TLS Certificate Management
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # NGINX Ingress Controller Settings
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/proxy-body-size: '10m'
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '60'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '60'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '60'
+    # Rate Limiting
+    nginx.ingress.kubernetes.io/limit-rps: '100'
+    nginx.ingress.kubernetes.io/limit-connections: '50'
+    # Security Headers
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header X-XSS-Protection "1; mode=block" always;
+      add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # WebSocket Support
+    nginx.ingress.kubernetes.io/proxy-http-version: '1.1'
+    nginx.ingress.kubernetes.io/upstream-hash-by: '$remote_addr'
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - hospital.example.com
+        - api.hospital.example.com
+      secretName: hospital-erp-tls
+  rules:
+    - host: hospital.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 3001
+    - host: api.hospital.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: backend
+                port:
+                  number: 3000

--- a/k8s/base/ingress/kustomization.yaml
+++ b/k8s/base/ingress/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cluster-issuer.yaml
+  - ingress.yaml

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
   - backend/service.yaml
   - frontend/deployment.yaml
   - frontend/service.yaml
+  - ingress/cluster-issuer.yaml
+  - ingress/ingress.yaml
 
 labels:
   - pairs:


### PR DESCRIPTION
## Summary

Closes #121

Add Kubernetes Ingress resources for the Hospital ERP System with NGINX Ingress Controller and TLS termination using cert-manager.

### Changes

- Add ClusterIssuer manifests for Let's Encrypt (staging and production)
- Add Ingress resource with host-based routing:
  - `hospital.example.com` → frontend service (port 3001)
  - `api.hospital.example.com` → backend service (port 3000)
- Configure TLS certificate auto-provisioning via cert-manager
- Add security headers (X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy)
- Add rate limiting (100 requests per second, 50 concurrent connections)
- Add WebSocket support with upstream hashing
- Update base kustomization.yaml with ingress resources
- Add `infra` and `k8s` scopes to commitlint configuration

## Prerequisites

Before deploying these manifests, ensure the following are installed in the cluster:

1. **NGINX Ingress Controller**:
   ```bash
   helm install ingress-nginx ingress-nginx/ingress-nginx \
     --namespace ingress-nginx \
     --create-namespace \
     --set controller.replicaCount=2
   ```

2. **cert-manager**:
   ```bash
   helm install cert-manager jetstack/cert-manager \
     --namespace cert-manager \
     --create-namespace \
     --set installCRDs=true
   ```

## Test Plan

- [ ] Verify `kubectl kustomize k8s/base` runs without errors
- [ ] Verify ClusterIssuer resources are valid YAML
- [ ] Verify Ingress resource routes correctly
- [ ] Deploy to staging environment and test TLS certificate provisioning
- [ ] Test rate limiting with load testing tools