### PR TITLE
feat(k8s): add configmaps and external secrets setup

### DIFF
--- a/k8s/base/configs/backend-config.yaml
+++ b/k8s/base/configs/backend-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backend-config
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: config
+data:
+  NODE_ENV: 'production'
+  PORT: '3000'
+  JWT_ACCESS_EXPIRATION: '1h'
+  JWT_REFRESH_EXPIRATION: '7d'
+  LOG_LEVEL: 'info'
+  CORS_ORIGIN: 'https://hospital.example.com'

--- a/k8s/base/configs/frontend-config.yaml
+++ b/k8s/base/configs/frontend-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: config
+data:
+  NEXT_PUBLIC_API_URL: 'https://api.hospital.example.com'
+  NEXT_PUBLIC_APP_NAME: 'Hospital ERP System'
+  NEXT_PUBLIC_APP_URL: 'https://hospital.example.com'

--- a/k8s/base/configs/kustomization.yaml
+++ b/k8s/base/configs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - backend-config.yaml
+  - frontend-config.yaml

--- a/k8s/base/external-secrets/README.md
+++ b/k8s/base/external-secrets/README.md
@@ -1,0 +1,85 @@
+# External Secrets Operator Setup
+
+This directory contains External Secrets Operator configuration for secure secrets management.
+
+## Prerequisites
+
+### 1. Install External Secrets Operator
+
+```bash
+# Add Helm repository
+helm repo add external-secrets https://charts.external-secrets.io
+helm repo update
+
+# Install External Secrets Operator
+helm install external-secrets external-secrets/external-secrets \
+  --namespace external-secrets \
+  --create-namespace \
+  --wait
+```
+
+### 2. Configure AWS IRSA (IAM Roles for Service Accounts)
+
+Create an IAM role with the following policy for Secrets Manager access:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"],
+      "Resource": "arn:aws:secretsmanager:ap-northeast-2:*:secret:hospital-erp/*"
+    }
+  ]
+}
+```
+
+### 3. Create Secrets in AWS Secrets Manager
+
+Create the following secrets in AWS Secrets Manager:
+
+- `hospital-erp/database` - Database credentials
+- `hospital-erp/backend` - Backend application secrets (JWT keys, API keys)
+- `hospital-erp/redis` - Redis authentication
+
+Example secret structure for `hospital-erp/database`:
+
+```json
+{
+  "url": "postgresql://user:password@host:5432/dbname",
+  "host": "your-rds-endpoint",
+  "port": "5432",
+  "username": "db_user",
+  "password": "db_password",
+  "database": "hospital_erp"
+}
+```
+
+## Files
+
+- `cluster-secret-store.yaml` - ClusterSecretStore configuration for AWS Secrets Manager
+- `external-secret-database.yaml` - ExternalSecret for database credentials
+- `external-secret-backend.yaml` - ExternalSecret for backend secrets
+- `external-secret-redis.yaml` - ExternalSecret for Redis credentials
+
+## Verification
+
+```bash
+# Check ClusterSecretStore status
+kubectl get clustersecretstore aws-secrets-manager -o yaml
+
+# Check ExternalSecrets sync status
+kubectl get externalsecret -n hospital-erp-system
+
+# Verify secrets are created
+kubectl get secrets -n hospital-erp-system
+```
+
+## Troubleshooting
+
+If secrets are not syncing:
+
+1. Check External Secrets Operator logs: `kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets`
+2. Verify IRSA configuration: `kubectl describe sa -n hospital-erp-system`
+3. Check SecretStore status: `kubectl describe clustersecretstore aws-secrets-manager`

--- a/k8s/base/external-secrets/cluster-secret-store.yaml
+++ b/k8s/base/external-secrets/cluster-secret-store.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secrets-manager
+  labels:
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/component: secret-store
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: ap-northeast-2
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: external-secrets-sa
+            namespace: hospital-erp-system

--- a/k8s/base/external-secrets/external-secret-backend.yaml
+++ b/k8s/base/external-secrets/external-secret-backend.yaml
@@ -1,0 +1,38 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: backend-secrets
+  labels:
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/component: backend
+spec:
+  refreshInterval: '1h'
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: backend-secrets
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          app.kubernetes.io/name: backend
+          app.kubernetes.io/component: credentials
+  data:
+    - secretKey: JWT_ACCESS_SECRET
+      remoteRef:
+        key: hospital-erp/backend
+        property: jwt_access_secret
+    - secretKey: JWT_REFRESH_SECRET
+      remoteRef:
+        key: hospital-erp/backend
+        property: jwt_refresh_secret
+    - secretKey: ENCRYPTION_KEY
+      remoteRef:
+        key: hospital-erp/backend
+        property: encryption_key
+    - secretKey: API_KEY
+      remoteRef:
+        key: hospital-erp/backend
+        property: api_key

--- a/k8s/base/external-secrets/external-secret-database.yaml
+++ b/k8s/base/external-secrets/external-secret-database.yaml
@@ -1,0 +1,46 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: database-credentials
+  labels:
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/component: database
+spec:
+  refreshInterval: '1h'
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: database-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          app.kubernetes.io/name: database
+          app.kubernetes.io/component: credentials
+  data:
+    - secretKey: DATABASE_URL
+      remoteRef:
+        key: hospital-erp/database
+        property: url
+    - secretKey: DATABASE_HOST
+      remoteRef:
+        key: hospital-erp/database
+        property: host
+    - secretKey: DATABASE_PORT
+      remoteRef:
+        key: hospital-erp/database
+        property: port
+    - secretKey: DATABASE_USERNAME
+      remoteRef:
+        key: hospital-erp/database
+        property: username
+    - secretKey: DATABASE_PASSWORD
+      remoteRef:
+        key: hospital-erp/database
+        property: password
+    - secretKey: DATABASE_NAME
+      remoteRef:
+        key: hospital-erp/database
+        property: database

--- a/k8s/base/external-secrets/external-secret-redis.yaml
+++ b/k8s/base/external-secrets/external-secret-redis.yaml
@@ -1,0 +1,38 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: redis-credentials
+  labels:
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/component: redis
+spec:
+  refreshInterval: '1h'
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: redis-credentials
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          app.kubernetes.io/name: redis
+          app.kubernetes.io/component: credentials
+  data:
+    - secretKey: REDIS_URL
+      remoteRef:
+        key: hospital-erp/redis
+        property: url
+    - secretKey: REDIS_HOST
+      remoteRef:
+        key: hospital-erp/redis
+        property: host
+    - secretKey: REDIS_PORT
+      remoteRef:
+        key: hospital-erp/redis
+        property: port
+    - secretKey: REDIS_PASSWORD
+      remoteRef:
+        key: hospital-erp/redis
+        property: password

--- a/k8s/base/external-secrets/kustomization.yaml
+++ b/k8s/base/external-secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service-account.yaml
+  - cluster-secret-store.yaml
+  - external-secret-database.yaml
+  - external-secret-backend.yaml
+  - external-secret-redis.yaml

--- a/k8s/base/external-secrets/service-account.yaml
+++ b/k8s/base/external-secrets/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-secrets-sa
+  labels:
+    app.kubernetes.io/name: external-secrets
+    app.kubernetes.io/component: service-account
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/hospital-erp-external-secrets

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -5,6 +5,13 @@ namespace: hospital-erp-system
 
 resources:
   - namespace.yaml
+  - configs/backend-config.yaml
+  - configs/frontend-config.yaml
+  - external-secrets/service-account.yaml
+  - external-secrets/cluster-secret-store.yaml
+  - external-secrets/external-secret-database.yaml
+  - external-secrets/external-secret-backend.yaml
+  - external-secrets/external-secret-redis.yaml
   - backend/deployment.yaml
   - backend/service.yaml
   - frontend/deployment.yaml


### PR DESCRIPTION
Closes #122

## Summary

- Add ConfigMaps for backend and frontend applications with production settings
- Integrate External Secrets Operator for secure secrets management from AWS Secrets Manager
- Create ClusterSecretStore with IRSA authentication for AWS integration
- Add ExternalSecrets for database, backend, and Redis credentials with 1-hour refresh interval
- Include comprehensive documentation for setup and troubleshooting

## Changes Made

### ConfigMaps
- `backend-config`: NODE_ENV, PORT, JWT settings, LOG_LEVEL, CORS configuration
- `frontend-config`: Public environment variables for Next.js application

### External Secrets
- `ClusterSecretStore`: AWS Secrets Manager integration for ap-northeast-2 region
- `ExternalSecret` for database credentials (DATABASE_URL, host, port, username, password)
- `ExternalSecret` for backend secrets (JWT secrets, encryption key, API key)
- `ExternalSecret` for Redis credentials (REDIS_URL, host, port, password)

### Documentation
- Added README.md with installation instructions for External Secrets Operator
- Included AWS IAM policy requirements for IRSA
- Added verification and troubleshooting guides

## Test Plan
- [x] Kustomize build validates successfully (`kubectl kustomize k8s/base/`)
- [ ] External Secrets Operator installed in cluster
- [ ] SecretStore configured and connected to AWS
- [ ] ExternalSecrets syncing correctly (1h refresh)
- [ ] No hardcoded secrets in manifests

## Prerequisites for Deployment
1. Install External Secrets Operator via Helm
2. Configure IRSA for the service account
3. Create secrets in AWS Secrets Manager