### PR TITLE
feat(k8s): implement network policies for zero-trust security

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -18,6 +18,13 @@ resources:
   - frontend/service.yaml
   - ingress/cluster-issuer.yaml
   - ingress/ingress.yaml
+  # Network Policies (Zero-Trust Security)
+  - network-policies/default-deny.yaml
+  - network-policies/allow-dns.yaml
+  - network-policies/frontend-policy.yaml
+  - network-policies/backend-policy.yaml
+  - network-policies/database-policy.yaml
+  - network-policies/redis-policy.yaml
 
 labels:
   - pairs:

--- a/k8s/base/network-policies/.gitkeep
+++ b/k8s/base/network-policies/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder for Network Policies
-# See issue #124 for implementation

--- a/k8s/base/network-policies/allow-dns.yaml
+++ b/k8s/base/network-policies/allow-dns.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  labels:
+    app.kubernetes.io/name: allow-dns-egress
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/k8s/base/network-policies/backend-policy.yaml
+++ b/k8s/base/network-policies/backend-policy.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-network-policy
+  labels:
+    app.kubernetes.io/name: backend-network-policy
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: backend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from ingress-nginx namespace (direct API access)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3000
+    # Allow traffic from frontend pods
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: frontend
+      ports:
+        - protocol: TCP
+          port: 3000
+    # Allow Prometheus metrics scraping from monitoring namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    # Allow traffic to PostgreSQL via PgBouncer
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: pgbouncer
+      ports:
+        - protocol: TCP
+          port: 6432
+    # Allow traffic to Redis
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis
+      ports:
+        - protocol: TCP
+          port: 6379

--- a/k8s/base/network-policies/database-policy.yaml
+++ b/k8s/base/network-policies/database-policy.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-network-policy
+  labels:
+    app.kubernetes.io/name: postgres-network-policy
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Only allow traffic from PgBouncer
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: pgbouncer
+      ports:
+        - protocol: TCP
+          port: 5432
+  egress:
+    # Allow PostgreSQL replication (pod-to-pod communication)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgres
+      ports:
+        - protocol: TCP
+          port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: pgbouncer-network-policy
+  labels:
+    app.kubernetes.io/name: pgbouncer-network-policy
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: pgbouncer
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Only allow traffic from backend
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+      ports:
+        - protocol: TCP
+          port: 6432
+  egress:
+    # Allow traffic to PostgreSQL
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: postgres
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/k8s/base/network-policies/default-deny.yaml
+++ b/k8s/base/network-policies/default-deny.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  labels:
+    app.kubernetes.io/name: default-deny-all
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/k8s/base/network-policies/frontend-policy.yaml
+++ b/k8s/base/network-policies/frontend-policy.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: frontend-network-policy
+  labels:
+    app.kubernetes.io/name: frontend-network-policy
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from ingress-nginx namespace
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 3001
+  egress:
+    # Allow traffic to backend service
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+      ports:
+        - protocol: TCP
+          port: 3000

--- a/k8s/base/network-policies/kustomization.yaml
+++ b/k8s/base/network-policies/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - default-deny.yaml
+  - allow-dns.yaml
+  - frontend-policy.yaml
+  - backend-policy.yaml
+  - database-policy.yaml
+  - redis-policy.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: hospital-erp-system
+      app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/network-policies/redis-policy.yaml
+++ b/k8s/base/network-policies/redis-policy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-network-policy
+  labels:
+    app.kubernetes.io/name: redis-network-policy
+    app.kubernetes.io/component: network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Only allow traffic from backend
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: backend
+      ports:
+        - protocol: TCP
+          port: 6379
+  egress:
+    # Allow Redis cluster replication (pod-to-pod communication)
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis
+      ports:
+        - protocol: TCP
+          port: 6379
+        - protocol: TCP
+          port: 16379


### PR DESCRIPTION
## Summary
- Implement Kubernetes NetworkPolicies to enforce zero-trust network security between services
- Add default-deny-all policy that blocks all ingress and egress traffic by default
- Configure explicit allow rules for authorized traffic flows only
- Enable DNS egress for all pods (required for service discovery)

## Changes Made

### Network Policies Added
| Policy | Purpose |
|--------|---------|
| `default-deny.yaml` | Blocks all ingress and egress traffic by default |
| `allow-dns.yaml` | Allows DNS queries to kube-dns for all pods |
| `frontend-policy.yaml` | Frontend can only receive from ingress-nginx and send to backend |
| `backend-policy.yaml` | Backend receives from ingress-nginx, frontend, and monitoring; sends to pgbouncer and redis |
| `database-policy.yaml` | PostgreSQL and PgBouncer policies for database isolation |
| `redis-policy.yaml` | Redis accepts only from backend, allows cluster replication |

### Network Flow
```
Internet -> Ingress -> Frontend (3001)
                    -> Backend (3000) -> PgBouncer (6432) -> PostgreSQL (5432)
                                      -> Redis (6379)
```

## Related Issues
Closes #124

## Test Plan
- [ ] Deploy to test cluster with NetworkPolicy-supporting CNI (Calico/Cilium)
- [ ] Verify frontend can access backend: `kubectl exec frontend-pod -- nc -zv backend 3000`
- [ ] Verify backend can access database: `kubectl exec backend-pod -- nc -zv pgbouncer 6432`
- [ ] Verify unauthorized connections are blocked: `kubectl exec frontend-pod -- nc -zv postgres 5432` (should fail)
- [ ] Verify DNS resolution works: `kubectl exec any-pod -- nslookup backend`

## Technical Notes
- Requires CNI that supports NetworkPolicies (Calico, Cilium, Weave, etc.)
- Labels follow Kubernetes recommended label convention (`app.kubernetes.io/name`)
- Policies are ready for database/redis deployments (issues #122, #123)