### PR TITLE
feat(k8s): configure rbac and service accounts for least privilege

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -18,6 +18,11 @@ resources:
   - frontend/service.yaml
   - ingress/cluster-issuer.yaml
   - ingress/ingress.yaml
+  # RBAC (Role-Based Access Control)
+  - rbac/service-accounts.yaml
+  - rbac/backend-role.yaml
+  - rbac/frontend-role.yaml
+  - rbac/role-bindings.yaml
   # Network Policies (Zero-Trust Security)
   - network-policies/default-deny.yaml
   - network-policies/allow-dns.yaml

--- a/k8s/base/rbac/.gitkeep
+++ b/k8s/base/rbac/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder for RBAC and Service Accounts
-# See issue #125 for implementation

--- a/k8s/base/rbac/backend-role.yaml
+++ b/k8s/base/rbac/backend-role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backend-role
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ['']
+    resources: ['configmaps']
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['']
+    resources: ['secrets']
+    resourceNames: ['backend-secrets', 'database-credentials', 'redis-credentials']
+    verbs: ['get', 'watch']
+  - apiGroups: ['']
+    resources: ['pods']
+    verbs: ['get', 'list']

--- a/k8s/base/rbac/frontend-role.yaml
+++ b/k8s/base/rbac/frontend-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: frontend-role
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ['']
+    resources: ['configmaps']
+    resourceNames: ['frontend-config']
+    verbs: ['get', 'watch']

--- a/k8s/base/rbac/kustomization.yaml
+++ b/k8s/base/rbac/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - service-accounts.yaml
+  - backend-role.yaml
+  - frontend-role.yaml
+  - role-bindings.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: hospital-erp-system
+      app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/rbac/role-bindings.yaml
+++ b/k8s/base/rbac/role-bindings.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backend-rolebinding
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: rbac
+subjects:
+  - kind: ServiceAccount
+    name: backend-sa
+roleRef:
+  kind: Role
+  name: backend-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: frontend-rolebinding
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: rbac
+subjects:
+  - kind: ServiceAccount
+    name: frontend-sa
+roleRef:
+  kind: Role
+  name: frontend-role
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s/base/rbac/service-accounts.yaml
+++ b/k8s/base/rbac/service-accounts.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend-sa
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: service-account
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: frontend-sa
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: service-account
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pgbouncer-sa
+  labels:
+    app.kubernetes.io/name: pgbouncer
+    app.kubernetes.io/component: service-account

--- a/k8s/monitoring/.gitkeep
+++ b/k8s/monitoring/.gitkeep
@@ -1,4 +1,0 @@
-# Placeholder for monitoring stack configuration
-# See issue #128 for Prometheus and Grafana setup
-# See issue #129 for Loki logging stack
-# See issue #130 for alerting rules

--- a/k8s/monitoring/prometheus/kustomization.yaml
+++ b/k8s/monitoring/prometheus/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - rbac.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: hospital-erp-system
+      app.kubernetes.io/managed-by: kustomize

--- a/k8s/monitoring/prometheus/rbac.yaml
+++ b/k8s/monitoring/prometheus/rbac.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-sa
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-role
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: rbac
+rules:
+  - apiGroups: ['']
+    resources:
+      - nodes
+      - nodes/metrics
+      - services
+      - endpoints
+      - pods
+    verbs: ['get', 'list', 'watch']
+  - apiGroups: ['']
+    resources: ['configmaps']
+    verbs: ['get']
+  - apiGroups: ['networking.k8s.io']
+    resources: ['ingresses']
+    verbs: ['get', 'list', 'watch']
+  - nonResourceURLs: ['/metrics', '/metrics/cadvisor']
+    verbs: ['get']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-rolebinding
+  labels:
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/component: rbac
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-sa
+    namespace: monitoring
+roleRef:
+  kind: ClusterRole
+  name: prometheus-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Closes #125

## Summary
- Configure Role-Based Access Control (RBAC) with dedicated Service Accounts for each application component
- Implement least privilege principle for backend, frontend, and monitoring components
- Add Prometheus ClusterRole for cluster-wide monitoring capabilities

## Changes Made

### Service Accounts
- `backend-sa`: For backend API pods
- `frontend-sa`: For frontend web pods
- `pgbouncer-sa`: For database connection pooler

### Roles and Permissions

| Component | Resources | Access Level |
|-----------|-----------|--------------|
| Backend | ConfigMaps, Secrets, Pods | Read-only (specific secrets only) |
| Frontend | ConfigMaps | Read-only (frontend-config only) |
| Prometheus | Nodes, Services, Endpoints, Pods | Cluster-wide read |

### Security Features
- Backend can only access specific named secrets (`backend-secrets`, `database-credentials`, `redis-credentials`)
- Frontend has minimal access (only its own config)
- Prometheus has read-only cluster access for metrics collection

## Test Plan
- [x] `kubectl kustomize k8s/base/` builds successfully
- [ ] Deploy to dev cluster and verify:
  - [ ] Backend pods can read their ConfigMaps and Secrets
  - [ ] Frontend pods can only read frontend-config
  - [ ] Prometheus can scrape metrics from all namespaces

## Related Issues
- Part of #117 (Epic: Kubernetes Deployment Implementation)
- Depends on #118 (Base Manifests Structure) - Already merged