### PR TITLE
feat(k8s): configure redis cluster for caching and session management

### DIFF
--- a/k8s/base/cache/.gitkeep
+++ b/k8s/base/cache/.gitkeep
@@ -1,2 +1,0 @@
-# Placeholder for Redis cache manifests
-# See issue #123 for implementation

--- a/k8s/base/cache/README.md
+++ b/k8s/base/cache/README.md
@@ -1,0 +1,147 @@
+# Redis Cache Configuration
+
+This directory contains Kubernetes manifests for Redis cache deployment.
+
+## Architecture
+
+### Development/Staging (Self-Hosted)
+
+Uses a single-replica StatefulSet with persistent storage:
+
+```
+┌─────────────────────────────────────────┐
+│ Hospital ERP Kubernetes Cluster         │
+│                                          │
+│   ┌─────────────────────────────┐       │
+│   │ Redis StatefulSet           │       │
+│   │   - 1 replica               │       │
+│   │   - AOF persistence         │       │
+│   │   - 256MB memory limit      │       │
+│   │   - Password authentication │       │
+│   └─────────────────────────────┘       │
+│             │                            │
+│             ▼                            │
+│   ┌─────────────────────────────┐       │
+│   │ PersistentVolumeClaim       │       │
+│   │   - 5Gi storage             │       │
+│   │   - ReadWriteOnce           │       │
+│   └─────────────────────────────┘       │
+└─────────────────────────────────────────┘
+```
+
+### Production (Managed Redis - AWS ElastiCache)
+
+For production environments, use AWS ElastiCache for Redis:
+
+```
+┌─────────────────────────────────────────┐
+│ Hospital ERP Kubernetes Cluster         │
+│                                          │
+│   ┌─────────────────────────────┐       │
+│   │ Backend Pods                │       │
+│   │   - Connects via REDIS_HOST │       │
+│   │   - Uses redis-credentials  │       │
+│   └─────────────┬───────────────┘       │
+│                 │                        │
+└─────────────────┼────────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│ AWS ElastiCache Redis Cluster           │
+│   - Multi-AZ deployment                 │
+│   - Automatic failover                  │
+│   - Encryption at rest & in transit     │
+│   - Managed backups                     │
+└─────────────────────────────────────────┘
+```
+
+## Files
+
+| File                     | Description                        |
+| ------------------------ | ---------------------------------- |
+| `redis-config.yaml`      | ConfigMap with Redis configuration |
+| `redis-statefulset.yaml` | StatefulSet for self-hosted Redis  |
+| `redis-service.yaml`     | ClusterIP and Headless services    |
+| `kustomization.yaml`     | Kustomize configuration            |
+
+## Configuration
+
+### Memory Settings
+
+- `maxmemory`: 256MB (adjustable via overlay patches)
+- `maxmemory-policy`: allkeys-lru (evict least recently used keys)
+
+### Persistence
+
+- **AOF (Append Only File)**: Enabled with `everysec` sync
+- **RDB Snapshots**: Configured for periodic backups
+
+### Security
+
+- Password authentication required
+- Protected mode enabled
+- Network policies restrict access to backend pods only
+
+## Production Setup (AWS ElastiCache)
+
+For production, skip the self-hosted Redis by removing it from the overlay:
+
+```yaml
+# k8s/overlays/production/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+# Exclude self-hosted Redis components
+patchesStrategicMerge:
+  - redis-managed-patch.yaml
+```
+
+Then configure the External Secret to point to ElastiCache:
+
+```yaml
+# AWS Secrets Manager secret should contain:
+{
+  'host': 'hospital-erp.xxxxx.0001.apn2.cache.amazonaws.com',
+  'port': '6379',
+  'password': '<auth-token>',
+  'url': 'redis://:password@host:port',
+}
+```
+
+## Monitoring
+
+Redis metrics are exposed via `redis_exporter` sidecar:
+
+- **Port**: 9121
+- **Path**: /metrics
+- **Prometheus scrape**: Enabled via pod annotations
+
+### Key Metrics
+
+- `redis_connected_clients`
+- `redis_used_memory`
+- `redis_commands_processed_total`
+- `redis_keyspace_hits_total` / `redis_keyspace_misses_total`
+
+## Troubleshooting
+
+### Check Redis Connection
+
+```bash
+kubectl exec -it redis-0 -n hospital-erp-system -- redis-cli -a $REDIS_PASSWORD ping
+```
+
+### View Redis Logs
+
+```bash
+kubectl logs redis-0 -n hospital-erp-system -c redis
+```
+
+### Check Memory Usage
+
+```bash
+kubectl exec -it redis-0 -n hospital-erp-system -- redis-cli -a $REDIS_PASSWORD info memory
+```

--- a/k8s/base/cache/kustomization.yaml
+++ b/k8s/base/cache/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - redis-config.yaml
+  - redis-statefulset.yaml
+  - redis-service.yaml

--- a/k8s/base/cache/redis-config.yaml
+++ b/k8s/base/cache/redis-config.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: config
+data:
+  redis.conf: |
+    # Network configuration
+    bind 0.0.0.0
+    port 6379
+    tcp-keepalive 300
+    timeout 0
+
+    # Memory management
+    maxmemory 256mb
+    maxmemory-policy allkeys-lru
+
+    # Persistence - AOF (Append Only File)
+    appendonly yes
+    appendfsync everysec
+    auto-aof-rewrite-percentage 100
+    auto-aof-rewrite-min-size 64mb
+
+    # RDB snapshots (backup)
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    # Security
+    protected-mode yes
+
+    # Logging
+    loglevel notice
+
+    # Performance tuning
+    tcp-backlog 511
+    databases 16
+
+    # Slow log (queries taking more than 10ms)
+    slowlog-log-slower-than 10000
+    slowlog-max-len 128

--- a/k8s/base/cache/redis-service.yaml
+++ b/k8s/base/cache/redis-service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP
+    - name: metrics
+      port: 9121
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-headless
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP

--- a/k8s/base/cache/redis-statefulset.yaml
+++ b/k8s/base/cache/redis-statefulset.yaml
@@ -1,0 +1,139 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+spec:
+  serviceName: redis-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: cache
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9121'
+    spec:
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          imagePullPolicy: IfNotPresent
+          command:
+            - redis-server
+            - /etc/redis/redis.conf
+            - --requirepass
+            - $(REDIS_PASSWORD)
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-credentials
+                  key: REDIS_PASSWORD
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a $REDIS_PASSWORD ping | grep PONG
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - redis-cli -a $REDIS_PASSWORD ping | grep PONG
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+            - name: redis-config
+              mountPath: /etc/redis
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+        - name: redis-exporter
+          image: oliver006/redis_exporter:v1.55.0-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: metrics
+              containerPort: 9121
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: redis-credentials
+                  key: REDIS_PASSWORD
+            - name: REDIS_ADDR
+              value: localhost:6379
+      volumes:
+        - name: redis-config
+          configMap:
+            name: redis-config
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+        labels:
+          app.kubernetes.io/name: redis
+          app.kubernetes.io/component: cache
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: standard
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -12,6 +12,11 @@ resources:
   - external-secrets/external-secret-database.yaml
   - external-secrets/external-secret-backend.yaml
   - external-secrets/external-secret-redis.yaml
+  # Redis Cache
+  - cache/redis-config.yaml
+  - cache/redis-statefulset.yaml
+  - cache/redis-service.yaml
+  # Backend Application
   - backend/deployment.yaml
   - backend/service.yaml
   - backend/hpa.yaml


### PR DESCRIPTION
Closes #123

## Summary
- Add Redis StatefulSet with persistent storage (5Gi) and password authentication
- Configure Redis with LRU eviction policy and AOF persistence for data durability
- Add ClusterIP and Headless services for Redis access within the cluster
- Add Redis Exporter sidecar for Prometheus metrics collection
- Document both self-hosted (dev/staging) and managed (AWS ElastiCache) deployment options

## Changes Made

### New Files
| File | Description |
|------|-------------|
| `k8s/base/cache/redis-statefulset.yaml` | StatefulSet with security contexts and resource limits |
| `k8s/base/cache/redis-config.yaml` | ConfigMap with Redis configuration |
| `k8s/base/cache/redis-service.yaml` | ClusterIP and Headless services |
| `k8s/base/cache/kustomization.yaml` | Kustomize configuration for cache directory |
| `k8s/base/cache/README.md` | Documentation and troubleshooting guide |

### Modified Files
| File | Change |
|------|--------|
| `k8s/base/kustomization.yaml` | Added Redis resources to base deployment |

## Test Plan
- [ ] `kubectl kustomize k8s/base/` builds without errors
- [ ] Redis StatefulSet includes password authentication
- [ ] Redis ConfigMap has AOF persistence enabled
- [ ] Services expose correct ports (6379 for Redis, 9121 for metrics)
- [ ] Documentation covers both self-hosted and managed options