### PR TITLE
feat(infra): add pod disruption budgets for high availability

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -39,6 +39,10 @@ resources:
   - network-policies/backend-policy.yaml
   - network-policies/database-policy.yaml
   - network-policies/redis-policy.yaml
+  # Pod Disruption Budgets (High Availability)
+  - pdb/backend-pdb.yaml
+  - pdb/frontend-pdb.yaml
+  - pdb/redis-pdb.yaml
 
 labels:
   - pairs:

--- a/k8s/base/pdb/backend-pdb.yaml
+++ b/k8s/base/pdb/backend-pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend-pdb
+  labels:
+    app.kubernetes.io/name: backend
+    app.kubernetes.io/component: api
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: backend

--- a/k8s/base/pdb/frontend-pdb.yaml
+++ b/k8s/base/pdb/frontend-pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: frontend-pdb
+  labels:
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/component: web
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: frontend

--- a/k8s/base/pdb/redis-pdb.yaml
+++ b/k8s/base/pdb/redis-pdb.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redis-pdb
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: cache
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis


### PR DESCRIPTION
Closes #127

## Summary

Implements Pod Disruption Budgets (PDB) to ensure high availability during voluntary disruptions like node upgrades and scheduled maintenance.

### Changes Made
- **Backend PDB**: minAvailable=2 (maintains service during node drains)
- **Frontend PDB**: minAvailable=2 (ensures web availability)
- **Redis PDB**: maxUnavailable=0 (protects session data integrity)

### Component Coverage
| Component | Strategy | Value | Reason |
|-----------|----------|-------|--------|
| Backend | minAvailable | 2 | Handle traffic during drain |
| Frontend | minAvailable | 2 | Handle traffic during drain |
| Redis | maxUnavailable | 0 | Session data critical |

## Technical Approach

PDBs are configured to:
1. Ensure minimum replicas for stateless services (Backend, Frontend)
2. Prevent disruption of stateful components (Redis)
3. Work seamlessly with existing HPA configurations
4. Comply with Kubernetes best practices

## Test Plan

1. **Validation**:
   ```bash
   kubectl kustomize k8s/base | grep -A 15 "kind: PodDisruptionBudget"
   ```
   ✅ All PDB manifests generated correctly

2. **Integration** (manual testing required):
   - Deploy to cluster
   - Attempt node drain
   - Verify PDB constraints are respected
   - Confirm rolling updates work correctly

## Files Changed
- `k8s/base/pdb/backend-pdb.yaml` (new)
- `k8s/base/pdb/frontend-pdb.yaml` (new)
- `k8s/base/pdb/redis-pdb.yaml` (new)
- `k8s/base/kustomization.yaml` (updated to include PDBs)

## Related Documentation
- [Kubernetes Pod Disruption Budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/)
- [SDS Reference]: Section 2.1 (Design Goals - Availability)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Manifests validated with `kubectl kustomize`
- [x] Common labels applied via Kustomize
- [x] No sensitive data exposed
- [x] Related issue linked with closing keyword