### PR TITLE
docs(api): add vital signs api route structure documentation

### DIFF
--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -330,7 +330,39 @@ Inpatient Management ERP
 | **SCR-08** | Rounding               | /rounds         | Physician       |
 | **SCR-09** | Admin                  | /admin          | Administrator   |
 
+> **Note**: The paths listed above are **frontend (UI) routes** for navigation. Backend API endpoints follow RESTful resource hierarchy. See Section 3.1.3 for the mapping between UI routes and API endpoints.
+
 > **Traceability Reference**: [PRD.md](PRD.md) Section 8
+
+#### 3.1.3 UI Route to API Endpoint Mapping
+
+The frontend routes (UI paths) and backend API endpoints serve different purposes:
+
+- **UI Routes**: Used for browser navigation and frontend routing (e.g., React Router)
+- **API Endpoints**: RESTful resource endpoints following parent-child hierarchy
+
+| Screen (UI Path) | API Endpoint(s)                            | Description                         |
+| ---------------- | ------------------------------------------ | ----------------------------------- |
+| /vitals/input    | POST /admissions/:admissionId/vitals       | Record vital signs for an admission |
+| /vitals/:id      | GET /admissions/:admissionId/vitals        | Get vital signs history             |
+| -                | GET /admissions/:admissionId/vitals/latest | Get latest vital signs              |
+| /admissions/new  | POST /admissions                           | Create new admission                |
+| /admissions/:id  | GET /admissions/:admissionId               | Get admission details               |
+| /patients        | GET /patients                              | List patients                       |
+| /patients/:id    | GET /patients/:patientId                   | Get patient details                 |
+| /rounds          | GET /rounds                                | List rounding sessions              |
+| /rounds/:id      | GET /rounds/:roundId                       | Get round details                   |
+
+**Design Rationale**:
+
+Vital signs use nested routes under admissions (`/admissions/:admissionId/vitals`) because:
+
+1. **Resource Ownership**: Vital signs belong to a specific admission record
+2. **Access Control**: Ensures vitals are always associated with a valid admission
+3. **RESTful Best Practice**: Parent-child relationship is clearly expressed in the URL
+4. **Consistency**: Other admission-related resources follow the same pattern (medications, nursing-notes, io)
+
+> **API Reference**: See [api-specification.md](reference/02-design/api-specification.md) Section 6 for complete API documentation
 
 ### 3.2 Hardware Interfaces
 

--- a/docs/reference/02-design/api-specification.md
+++ b/docs/reference/02-design/api-specification.md
@@ -865,6 +865,31 @@ GET /admissions/{admissionId}/transfers
 
 ## 6. Reports and Logs API
 
+This section covers APIs for patient reports and logs. All endpoints in this section use **nested routes under admissions** following the RESTful parent-child resource pattern.
+
+### Nested Route Structure
+
+All clinical data (vitals, medications, I/O, nursing notes, daily reports) are accessed through the admission resource:
+
+```
+/admissions/{admissionId}/vitals          - Vital signs
+/admissions/{admissionId}/medications     - Medication records
+/admissions/{admissionId}/io              - Intake/Output records
+/admissions/{admissionId}/notes           - Nursing notes
+/admissions/{admissionId}/daily-reports   - Daily aggregated reports
+```
+
+**Design Rationale**:
+
+| Aspect              | Benefit                                                |
+| ------------------- | ------------------------------------------------------ |
+| **Ownership**       | Clear parent-child relationship (Admission owns data)  |
+| **Access Control**  | Validates admission exists before accessing child data |
+| **Query Scope**     | Natural filtering by admission context                 |
+| **URL Consistency** | Uniform pattern across all clinical data endpoints     |
+
+> **Note**: Frontend UI routes (e.g., `/vitals/input`) differ from API endpoints. See [SRS.md](../../SRS.md) Section 3.1.3 for the complete UI-to-API mapping.
+
 ### 6.1 Record Vital Signs
 
 ```http


### PR DESCRIPTION
## Summary
- Add UI route to API endpoint mapping table in SRS.md Section 3.1.3
- Clarify distinction between frontend routes and backend API endpoints
- Document nested route structure rationale in api-specification.md
- Add cross-references between SRS and API specification

## What
Documents the relationship between frontend UI routes (e.g., `/vitals/input`) and backend API endpoints (e.g., `/admissions/:admissionId/vitals`), addressing the confusion noted in the original issue.

## Why
The SRS documentation previously showed only frontend paths without explaining that API endpoints follow a different (nested) structure. This caused confusion when developers expected `/vitals/*` API endpoints but found `/admissions/:admissionId/vitals` in the implementation.

Closes #169

## Test Plan
- [ ] Documentation renders correctly on GitHub
- [ ] Cross-references between SRS and API specification work
- [ ] Table formatting is correct in both files