### PR TITLE
fix(auth): add authentication guards to admission, room, and rounding controllers

### DIFF
--- a/apps/backend/src/modules/admission/admission.controller.ts
+++ b/apps/backend/src/modules/admission/admission.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Query, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -8,7 +8,11 @@ import {
   ApiQuery,
 } from '@nestjs/swagger';
 import { AdmissionService } from './admission.service';
-import { ParseUUIDPipe } from '../../common';
+import { ParseUUIDPipe, CurrentUser } from '../../common';
+import { JwtAuthGuard } from '../../common/guards';
+import { PermissionGuard } from '../auth/guards';
+import { RequirePermission } from '../auth/decorators';
+import { Permissions } from '../auth/constants';
 import { AdmissionStatus } from '@prisma/client';
 import {
   CreateAdmissionDto,
@@ -23,6 +27,7 @@ import {
 
 @ApiTags('admissions')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionGuard)
 @Controller('admissions')
 export class AdmissionController {
   constructor(private readonly admissionService: AdmissionService) {}
@@ -36,13 +41,13 @@ export class AdmissionController {
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 409, description: 'Bed is already occupied or patient already admitted' })
+  @RequirePermission(Permissions.ADMISSION_CREATE)
   @Post()
   async create(
     @Body() dto: CreateAdmissionDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<AdmissionResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.admissionService.admitPatient(dto, effectiveUserId);
+    return this.admissionService.admitPatient(dto, user.id);
   }
 
   @ApiOperation({ summary: 'Get all admissions with pagination and filters' })
@@ -52,6 +57,7 @@ export class AdmissionController {
     type: PaginatedAdmissionsResponseDto,
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @RequirePermission(Permissions.ADMISSION_READ)
   @Get()
   async findAll(@Query() dto: FindAdmissionsDto): Promise<PaginatedAdmissionsResponseDto> {
     return this.admissionService.findAll(dto);
@@ -62,6 +68,7 @@ export class AdmissionController {
   @ApiResponse({ status: 200, description: 'Admission found', type: AdmissionResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Admission not found' })
+  @RequirePermission(Permissions.ADMISSION_READ)
   @Get('by-number/:admissionNumber')
   async findByAdmissionNumber(
     @Param('admissionNumber') admissionNumber: string,
@@ -77,6 +84,7 @@ export class AdmissionController {
     type: AdmissionResponseDto,
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @RequirePermission(Permissions.ADMISSION_READ)
   @Get('patient/:patientId/active')
   async findActiveByPatient(
     @Param('patientId', ParseUUIDPipe) patientId: string,
@@ -98,6 +106,7 @@ export class AdmissionController {
     type: [AdmissionResponseDto],
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @RequirePermission(Permissions.ADMISSION_READ)
   @Get('floor/:floorId')
   async findByFloor(
     @Param('floorId', ParseUUIDPipe) floorId: string,
@@ -111,6 +120,7 @@ export class AdmissionController {
   @ApiResponse({ status: 200, description: 'Admission found', type: AdmissionResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Admission not found' })
+  @RequirePermission(Permissions.ADMISSION_READ)
   @Get(':id')
   async findById(@Param('id', ParseUUIDPipe) id: string): Promise<AdmissionResponseDto> {
     return this.admissionService.findById(id);
@@ -127,14 +137,14 @@ export class AdmissionController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Admission not found' })
   @ApiResponse({ status: 409, description: 'Target bed is occupied' })
+  @RequirePermission(Permissions.ADMISSION_UPDATE)
   @Post(':id/transfer')
   async transfer(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: TransferDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<TransferResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.admissionService.transferPatient(id, dto, effectiveUserId);
+    return this.admissionService.transferPatient(id, dto, user.id);
   }
 
   @ApiOperation({ summary: 'Discharge patient' })
@@ -148,14 +158,14 @@ export class AdmissionController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Admission not found' })
   @ApiResponse({ status: 409, description: 'Patient already discharged' })
+  @RequirePermission(Permissions.ADMISSION_UPDATE)
   @Post(':id/discharge')
   async discharge(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: DischargeDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<DischargeResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.admissionService.dischargePatient(id, dto, effectiveUserId);
+    return this.admissionService.dischargePatient(id, dto, user.id);
   }
 
   @ApiOperation({ summary: 'Get transfer history for an admission' })
@@ -163,6 +173,7 @@ export class AdmissionController {
   @ApiResponse({ status: 200, description: 'List of transfers', type: [TransferResponseDto] })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Admission not found' })
+  @RequirePermission(Permissions.ADMISSION_READ)
   @Get(':id/transfers')
   async getTransferHistory(@Param('id', ParseUUIDPipe) id: string): Promise<TransferResponseDto[]> {
     return this.admissionService.getTransferHistory(id);

--- a/apps/backend/src/modules/admission/admission.module.ts
+++ b/apps/backend/src/modules/admission/admission.module.ts
@@ -4,9 +4,10 @@ import { AdmissionService } from './admission.service';
 import { AdmissionRepository } from './admission.repository';
 import { AdmissionNumberGenerator } from './admission-number.generator';
 import { RoomModule } from '../room';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [RoomModule],
+  imports: [RoomModule, AuthModule],
   controllers: [AdmissionController],
   providers: [AdmissionService, AdmissionRepository, AdmissionNumberGenerator],
   exports: [AdmissionService, AdmissionRepository],

--- a/apps/backend/src/modules/room/room.controller.ts
+++ b/apps/backend/src/modules/room/room.controller.ts
@@ -1,8 +1,29 @@
-import { Controller, Get, Patch, Post, Param, Query, Body, ParseUUIDPipe } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Patch,
+  Post,
+  Param,
+  Query,
+  Body,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { RoomService } from './room.service';
 import { BedService } from './bed.service';
 import { RoomDashboardService } from './room-dashboard.service';
+import { JwtAuthGuard } from '../../common/guards';
+import { PermissionGuard } from '../auth/guards';
+import { RequirePermission } from '../auth/decorators';
+import { Permissions } from '../auth/constants';
 import {
   FindAvailableBedsDto,
   UpdateBedStatusDto,
@@ -15,6 +36,8 @@ import {
 } from './dto';
 
 @ApiTags('rooms')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionGuard)
 @Controller('rooms')
 export class RoomController {
   constructor(
@@ -23,6 +46,7 @@ export class RoomController {
     private readonly roomDashboardService: RoomDashboardService,
   ) {}
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get all buildings' })
   @ApiResponse({ status: 200, description: 'Building list', type: [BuildingResponseDto] })
   @Get('buildings')
@@ -30,6 +54,7 @@ export class RoomController {
     return this.roomService.findAllBuildings();
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get building by ID' })
   @ApiParam({ name: 'id', description: 'Building ID' })
   @ApiResponse({ status: 200, description: 'Building found', type: BuildingResponseDto })
@@ -39,6 +64,7 @@ export class RoomController {
     return this.roomService.findBuildingById(id);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get floors by building' })
   @ApiParam({ name: 'buildingId', description: 'Building ID' })
   @ApiResponse({ status: 200, description: 'Floor list', type: [FloorResponseDto] })
@@ -47,6 +73,7 @@ export class RoomController {
     return this.roomService.findFloorsByBuilding(buildingId);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get rooms by floor' })
   @ApiParam({ name: 'floorId', description: 'Floor ID' })
   @ApiResponse({ status: 200, description: 'Room list', type: [RoomResponseDto] })
@@ -55,6 +82,7 @@ export class RoomController {
     return this.roomService.findRoomsByFloor(floorId);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get room by ID' })
   @ApiParam({ name: 'id', description: 'Room ID' })
   @ApiResponse({ status: 200, description: 'Room found', type: RoomResponseDto })
@@ -64,6 +92,7 @@ export class RoomController {
     return this.roomService.findRoomById(id);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get available beds' })
   @ApiResponse({ status: 200, description: 'Available beds', type: [BedResponseDto] })
   @Get('beds/available')
@@ -71,6 +100,7 @@ export class RoomController {
     return this.bedService.findAvailable(query);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get bed by ID' })
   @ApiParam({ name: 'id', description: 'Bed ID' })
   @ApiResponse({ status: 200, description: 'Bed found', type: BedResponseDto })
@@ -80,6 +110,7 @@ export class RoomController {
     return this.bedService.findById(id);
   }
 
+  @RequirePermission(Permissions.ROOM_ASSIGN)
   @ApiOperation({ summary: 'Update bed status' })
   @ApiParam({ name: 'id', description: 'Bed ID' })
   @ApiResponse({ status: 200, description: 'Bed status updated', type: BedResponseDto })
@@ -88,6 +119,7 @@ export class RoomController {
     return this.bedService.updateStatus(id, dto);
   }
 
+  @RequirePermission(Permissions.ROOM_ASSIGN)
   @ApiOperation({ summary: 'Occupy bed with admission' })
   @ApiParam({ name: 'id', description: 'Bed ID' })
   @ApiBody({ schema: { properties: { admissionId: { type: 'string', format: 'uuid' } } } })
@@ -100,6 +132,7 @@ export class RoomController {
     return this.bedService.occupy(id, admissionId);
   }
 
+  @RequirePermission(Permissions.ROOM_ASSIGN)
   @ApiOperation({ summary: 'Release bed' })
   @ApiParam({ name: 'id', description: 'Bed ID' })
   @ApiResponse({ status: 200, description: 'Bed released', type: BedResponseDto })
@@ -108,6 +141,7 @@ export class RoomController {
     return this.bedService.release(id);
   }
 
+  @RequirePermission(Permissions.ROOM_ASSIGN)
   @ApiOperation({ summary: 'Reserve bed' })
   @ApiParam({ name: 'id', description: 'Bed ID' })
   @ApiResponse({ status: 200, description: 'Bed reserved', type: BedResponseDto })
@@ -116,6 +150,7 @@ export class RoomController {
     return this.bedService.reserve(id);
   }
 
+  @RequirePermission(Permissions.ROOM_ASSIGN)
   @ApiOperation({ summary: 'Set bed to maintenance' })
   @ApiParam({ name: 'id', description: 'Bed ID' })
   @ApiBody({ schema: { properties: { notes: { type: 'string' } } } })
@@ -125,6 +160,7 @@ export class RoomController {
     return this.bedService.setMaintenance(id, notes);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get all buildings dashboard' })
   @ApiResponse({ status: 200, description: 'Buildings dashboard', type: [BuildingDashboard] })
   @Get('dashboard/buildings')
@@ -132,6 +168,7 @@ export class RoomController {
     return this.roomDashboardService.getAllBuildingsDashboard();
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get building dashboard' })
   @ApiParam({ name: 'buildingId', description: 'Building ID' })
   @ApiResponse({ status: 200, description: 'Building dashboard', type: BuildingDashboard })
@@ -140,6 +177,7 @@ export class RoomController {
     return this.roomDashboardService.getBuildingDashboard(buildingId);
   }
 
+  @RequirePermission(Permissions.ROOM_READ)
   @ApiOperation({ summary: 'Get floor dashboard' })
   @ApiParam({ name: 'floorId', description: 'Floor ID' })
   @ApiResponse({ status: 200, description: 'Floor dashboard', type: FloorDashboard })

--- a/apps/backend/src/modules/rounding/rounding.controller.ts
+++ b/apps/backend/src/modules/rounding/rounding.controller.ts
@@ -1,15 +1,12 @@
-import { Controller, Get, Post, Patch, Body, Param, Query, Headers } from '@nestjs/common';
-import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
-  ApiBearerAuth,
-  ApiParam,
-  ApiHeader,
-} from '@nestjs/swagger';
+import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { RoundingService } from './rounding.service';
 import { TabletRoundingService } from './tablet-rounding.service';
-import { ParseUUIDPipe } from '../../common';
+import { ParseUUIDPipe, CurrentUser } from '../../common';
+import { JwtAuthGuard } from '../../common/guards';
+import { PermissionGuard } from '../auth/guards';
+import { RequirePermission } from '../auth/decorators';
+import { Permissions } from '../auth/constants';
 import {
   CreateRoundDto,
   CreateRoundRecordDto,
@@ -23,6 +20,7 @@ import {
 
 @ApiTags('rounds')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard, PermissionGuard)
 @Controller('rounds')
 export class RoundController {
   constructor(
@@ -30,20 +28,20 @@ export class RoundController {
     private readonly tabletRoundingService: TabletRoundingService,
   ) {}
 
+  @RequirePermission(Permissions.ROUND_WRITE)
   @ApiOperation({ summary: 'Create a new rounding session' })
-  @ApiHeader({ name: 'x-user-id', description: 'User ID creating the round', required: false })
   @ApiResponse({ status: 201, description: 'Round created successfully', type: RoundResponseDto })
   @ApiResponse({ status: 400, description: 'Invalid input data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @Post()
   async create(
     @Body() dto: CreateRoundDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<RoundResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.roundingService.createSession(dto, effectiveUserId);
+    return this.roundingService.createSession(dto, user.id);
   }
 
+  @RequirePermission(Permissions.ROUND_READ)
   @ApiOperation({ summary: 'Get all rounding sessions with filters' })
   @ApiResponse({ status: 200, description: 'List of rounds', type: PaginatedRoundsResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
@@ -57,6 +55,7 @@ export class RoundController {
   @ApiResponse({ status: 200, description: 'Round details', type: RoundResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_READ)
   @Get('by-number/:roundNumber')
   async findByRoundNumber(@Param('roundNumber') roundNumber: string): Promise<RoundResponseDto> {
     return this.roundingService.findByRoundNumber(roundNumber);
@@ -67,6 +66,7 @@ export class RoundController {
   @ApiResponse({ status: 200, description: 'Round details', type: RoundResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_READ)
   @Get(':id')
   async findById(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.findById(id);
@@ -78,6 +78,7 @@ export class RoundController {
   @ApiResponse({ status: 400, description: 'Invalid state transition' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_WRITE)
   @Post(':id/start')
   async start(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.startSession(id);
@@ -89,6 +90,7 @@ export class RoundController {
   @ApiResponse({ status: 400, description: 'Invalid state transition' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_WRITE)
   @Post(':id/pause')
   async pause(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.pauseSession(id);
@@ -100,6 +102,7 @@ export class RoundController {
   @ApiResponse({ status: 400, description: 'Invalid state transition' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_WRITE)
   @Post(':id/resume')
   async resume(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.resumeSession(id);
@@ -111,6 +114,7 @@ export class RoundController {
   @ApiResponse({ status: 400, description: 'Invalid state transition' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_WRITE)
   @Post(':id/complete')
   async complete(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.completeSession(id);
@@ -122,6 +126,7 @@ export class RoundController {
   @ApiResponse({ status: 400, description: 'Invalid state transition' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_WRITE)
   @Post(':id/cancel')
   async cancel(@Param('id', ParseUUIDPipe) id: string): Promise<RoundResponseDto> {
     return this.roundingService.cancelSession(id);
@@ -136,6 +141,7 @@ export class RoundController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_READ)
   @Get(':id/patients')
   async getPatientList(@Param('id', ParseUUIDPipe) id: string): Promise<RoundingPatientListDto> {
     return this.tabletRoundingService.getRoundingPatientList(id);
@@ -150,14 +156,15 @@ export class RoundController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Round not found' })
+  @RequirePermission(Permissions.ROUND_READ)
   @Get(':id/records')
   async getRecords(@Param('id', ParseUUIDPipe) id: string): Promise<RoundRecordResponseDto[]> {
     return this.roundingService.getRecordsByRound(id);
   }
 
+  @RequirePermission(Permissions.ROUND_WRITE)
   @ApiOperation({ summary: 'Add a record to a rounding session' })
   @ApiParam({ name: 'id', description: 'Round UUID' })
-  @ApiHeader({ name: 'x-user-id', description: 'User ID recording the round', required: false })
   @ApiResponse({
     status: 201,
     description: 'Record added successfully',
@@ -170,16 +177,15 @@ export class RoundController {
   async addRecord(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: CreateRoundRecordDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<RoundRecordResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.tabletRoundingService.addRoundRecord(id, dto, effectiveUserId);
+    return this.tabletRoundingService.addRoundRecord(id, dto, user.id);
   }
 
+  @RequirePermission(Permissions.ROUND_WRITE)
   @ApiOperation({ summary: 'Update a round record' })
   @ApiParam({ name: 'id', description: 'Round UUID' })
   @ApiParam({ name: 'recordId', description: 'Record UUID' })
-  @ApiHeader({ name: 'x-user-id', description: 'User ID updating the record', required: false })
   @ApiResponse({
     status: 200,
     description: 'Record updated successfully',
@@ -193,9 +199,8 @@ export class RoundController {
     @Param('id', ParseUUIDPipe) id: string,
     @Param('recordId', ParseUUIDPipe) recordId: string,
     @Body() dto: UpdateRoundRecordDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<RoundRecordResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.roundingService.updateRecord(id, recordId, dto, effectiveUserId);
+    return this.roundingService.updateRecord(id, recordId, dto, user.id);
   }
 }

--- a/apps/backend/src/modules/rounding/rounding.module.ts
+++ b/apps/backend/src/modules/rounding/rounding.module.ts
@@ -3,9 +3,10 @@ import { RoundController } from './rounding.controller';
 import { RoundingService } from './rounding.service';
 import { TabletRoundingService } from './tablet-rounding.service';
 import { RoundingRepository } from './rounding.repository';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [],
+  imports: [AuthModule],
   controllers: [RoundController],
   providers: [RoundingService, TabletRoundingService, RoundingRepository],
   exports: [RoundingService, TabletRoundingService, RoundingRepository],


### PR DESCRIPTION
## Summary
- Add `JwtAuthGuard` and `PermissionGuard` to all endpoints in admission, room, and rounding controllers
- Replace insecure `x-user-id` header pattern with `@CurrentUser()` decorator for JWT-based user extraction
- Add `AuthModule` imports to admission and rounding modules for DI resolution

## Changes
- **AdmissionController**: Add class-level `@UseGuards`, `@RequirePermission` per endpoint, replace `@Headers('x-user-id')` with `@CurrentUser()`
- **RoomController**: Add `@ApiBearerAuth()`, `@UseGuards`, and `@RequirePermission` per endpoint
- **RoundingController**: Add class-level `@UseGuards`, `@RequirePermission` per endpoint, replace `@Headers('x-user-id')` with `@CurrentUser()`

## Test plan
- [ ] Verify TypeScript compilation passes for modified files
- [ ] Verify all endpoints require JWT authentication
- [ ] Verify permission-based access control per endpoint

Closes #183