### PR TITLE
fix(auth): replace x-user-id header with jwt-based user extraction in report controllers

### DIFF
--- a/apps/backend/src/modules/report/daily-report.controller.ts
+++ b/apps/backend/src/modules/report/daily-report.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { DailyReportAggregatorService } from './daily-report-aggregator.service';
-import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
+import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import {
   DailySummaryResponseDto,
@@ -66,11 +66,11 @@ export class DailyReportController {
   async generateReport(
     @Param('admissionId', ParseUUIDPipe) admissionId: string,
     @Param('date') date: string,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<DailyReportResponseDto> {
     const reportDate = new Date(date);
     reportDate.setHours(0, 0, 0, 0);
-    return this.aggregatorService.saveReport(admissionId, reportDate, userId);
+    return this.aggregatorService.saveReport(admissionId, reportDate, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/intake-output.controller.ts
+++ b/apps/backend/src/modules/report/intake-output.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { IntakeOutputService } from './intake-output.service';
-import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
+import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import { RecordIODto } from './dto/record-io.dto';
 import {
@@ -46,10 +46,9 @@ export class IntakeOutputController {
   async record(
     @Param('admissionId', ParseUUIDPipe) admissionId: string,
     @Body() dto: RecordIODto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<IntakeOutputResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.ioService.record(admissionId, dto, effectiveUserId);
+    return this.ioService.record(admissionId, dto, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/medication.controller.ts
+++ b/apps/backend/src/modules/report/medication.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { MedicationService } from './medication.service';
-import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
+import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import {
   ScheduleMedicationDto,
@@ -72,10 +72,9 @@ export class MedicationController {
   async administer(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: AdministerMedicationDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<MedicationResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.medicationService.administer(id, dto, effectiveUserId);
+    return this.medicationService.administer(id, dto, user.id);
   }
 
   /**
@@ -99,10 +98,9 @@ export class MedicationController {
   async hold(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: HoldMedicationDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<MedicationResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.medicationService.hold(id, dto, effectiveUserId);
+    return this.medicationService.hold(id, dto, user.id);
   }
 
   /**
@@ -126,10 +124,9 @@ export class MedicationController {
   async refuse(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: RefuseMedicationDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<MedicationResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.medicationService.refuse(id, dto, effectiveUserId);
+    return this.medicationService.refuse(id, dto, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/nursing-note.controller.ts
+++ b/apps/backend/src/modules/report/nursing-note.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { NursingNoteService } from './nursing-note.service';
-import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
+import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import {
   CreateNursingNoteDto,
@@ -44,10 +44,9 @@ export class NursingNoteController {
   async create(
     @Param('admissionId', ParseUUIDPipe) admissionId: string,
     @Body() dto: CreateNursingNoteDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<NursingNoteResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.noteService.create(admissionId, dto, effectiveUserId);
+    return this.noteService.create(admissionId, dto, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/vital-sign.controller.ts
+++ b/apps/backend/src/modules/report/vital-sign.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards, Headers } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { VitalSignService } from './vital-sign.service';
-import { ParseUUIDPipe, JwtAuthGuard } from '../../common';
+import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import {
   RecordVitalSignsDto,
@@ -46,10 +46,9 @@ export class VitalSignController {
   async record(
     @Param('admissionId', ParseUUIDPipe) admissionId: string,
     @Body() dto: RecordVitalSignsDto,
-    @Headers('x-user-id') userId?: string,
+    @CurrentUser() user: { id: string },
   ): Promise<VitalSignResponseDto> {
-    const effectiveUserId = userId || '00000000-0000-0000-0000-000000000000';
-    return this.vitalSignService.record(admissionId, dto, effectiveUserId);
+    return this.vitalSignService.record(admissionId, dto, user.id);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replace all `@Headers('x-user-id')` with `@CurrentUser()` decorator in 5 report controllers
- Remove nil UUID fallback pattern (`00000000-0000-0000-0000-000000000000`) to ensure audit trails use authenticated JWT user identity
- Affected controllers: vital-sign, intake-output, nursing-note, medication, daily-report

## Changes
- **VitalSignController**: Replace `x-user-id` header in `record()` with `@CurrentUser()`
- **IntakeOutputController**: Replace `x-user-id` header in `record()` with `@CurrentUser()`
- **NursingNoteController**: Replace `x-user-id` header in `create()` with `@CurrentUser()`
- **MedicationController**: Replace `x-user-id` header in `administer()`, `hold()`, `refuse()` with `@CurrentUser()`
- **DailyReportController**: Replace `x-user-id` header in `generateReport()` with `@CurrentUser()`

## Test plan
- [ ] Verify no `x-user-id` pattern remains in codebase
- [ ] Verify TypeScript compilation passes for modified files
- [ ] Verify all write endpoints extract user from JWT token

Closes #184