### PR TITLE
fix(frontend): align api paths with backend route structure

### DIFF
--- a/apps/frontend/src/services/auth-api.ts
+++ b/apps/frontend/src/services/auth-api.ts
@@ -7,10 +7,10 @@ import type {
 } from '@/types';
 
 const AUTH_ENDPOINTS = {
-  LOGIN: '/api/v1/auth/login',
-  LOGOUT: '/api/v1/auth/logout',
-  REFRESH: '/api/v1/auth/refresh',
-  CHANGE_PASSWORD: '/api/v1/auth/change-password',
+  LOGIN: '/auth/login',
+  LOGOUT: '/auth/logout',
+  REFRESH: '/auth/refresh',
+  CHANGE_PASSWORD: '/auth/change-password',
 } as const;
 
 export async function login(credentials: LoginCredentials): Promise<LoginResponse> {

--- a/apps/frontend/src/services/room-api.ts
+++ b/apps/frontend/src/services/room-api.ts
@@ -2,10 +2,20 @@ import { apiGet } from '@/lib/api-client';
 import type { Floor, FloorDashboard, AvailableBed, AvailableBedFilters } from '@/types';
 
 const ROOM_ENDPOINTS = {
-  FLOORS: '/api/v1/floors',
-  FLOOR_DASHBOARD: '/api/v1/rooms/floor-dashboard',
-  AVAILABLE_BEDS: '/api/v1/beds/available',
+  BUILDINGS: '/rooms/buildings',
+  FLOOR_DASHBOARD: '/rooms/dashboard/floor',
+  AVAILABLE_BEDS: '/rooms/beds/available',
 } as const;
+
+interface BuildingResponse {
+  id: string;
+  name: string;
+  floors?: Array<{
+    id: string;
+    name: string;
+    floorNumber: number;
+  }>;
+}
 
 function buildAvailableBedsQuery(filters: AvailableBedFilters): string {
   const searchParams = new URLSearchParams();
@@ -18,8 +28,16 @@ function buildAvailableBedsQuery(filters: AvailableBedFilters): string {
 }
 
 export const roomApi = {
-  getFloors: (): Promise<Floor[]> => {
-    return apiGet<Floor[]>(ROOM_ENDPOINTS.FLOORS);
+  getFloors: async (): Promise<Floor[]> => {
+    const buildings = await apiGet<BuildingResponse[]>(ROOM_ENDPOINTS.BUILDINGS);
+    return buildings.flatMap((building) =>
+      (building.floors || []).map((floor) => ({
+        id: floor.id,
+        name: floor.name,
+        floorNumber: floor.floorNumber,
+        building: building.name,
+      })),
+    );
   },
 
   getFloorDashboard: (floorId: string): Promise<FloorDashboard> => {


### PR DESCRIPTION
## Summary
- Remove `/api/v1/` prefix from auth-api.ts endpoints to match backend bare routes
- Fix room-api.ts paths to match actual backend route structure
- Adapt `getFloors()` to use `/rooms/buildings` endpoint and extract floor data from building response

## Changes
- **auth-api.ts**: `/api/v1/auth/login` → `/auth/login` (and all other auth endpoints)
- **room-api.ts**: 
  - `FLOORS`: `/api/v1/floors` → fetch from `/rooms/buildings` and flatten floors (no `/floors` backend endpoint exists)
  - `FLOOR_DASHBOARD`: `/api/v1/rooms/floor-dashboard` → `/rooms/dashboard/floor` (matches backend route)
  - `AVAILABLE_BEDS`: `/api/v1/beds/available` → `/rooms/beds/available` (matches backend route)

## Test plan
- [ ] Verify login flow works with corrected auth paths
- [ ] Verify room dashboard loads floor data via buildings endpoint
- [ ] Verify available beds API resolves correctly
- [ ] Verify no `/api/v1/` prefix remains in frontend services

Closes #185