### PR TITLE
fix(config): enforce encryption key and jwt secret strength in production

### DIFF
--- a/apps/backend/src/config/env.validation.ts
+++ b/apps/backend/src/config/env.validation.ts
@@ -1,5 +1,13 @@
 import { plainToInstance } from 'class-transformer';
-import { IsEnum, IsNumber, IsOptional, IsString, validateSync } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MinLength,
+  ValidateIf,
+  validateSync,
+} from 'class-validator';
 
 export enum Environment {
   Development = 'development',
@@ -18,14 +26,16 @@ export class EnvironmentVariables {
   @IsString()
   DATABASE_URL: string;
 
+  @ValidateIf((o) => o.NODE_ENV === Environment.Production)
   @IsString()
-  @IsOptional()
   REDIS_URL?: string;
 
   @IsString()
+  @MinLength(32)
   JWT_ACCESS_SECRET: string;
 
   @IsString()
+  @MinLength(32)
   JWT_REFRESH_SECRET: string;
 
   @IsString()
@@ -36,8 +46,9 @@ export class EnvironmentVariables {
   @IsOptional()
   JWT_REFRESH_EXPIRATION?: string = '7d';
 
+  @ValidateIf((o) => o.NODE_ENV === Environment.Production)
   @IsString()
-  @IsOptional()
+  @MinLength(32)
   ENCRYPTION_KEY?: string;
 
   @IsString()
@@ -72,6 +83,12 @@ export function validate(config: Record<string, unknown>) {
 
   if (errors.length > 0) {
     throw new Error(errors.toString());
+  }
+
+  if (validatedConfig.NODE_ENV !== Environment.Production && !validatedConfig.ENCRYPTION_KEY) {
+    console.warn(
+      '[WARNING] ENCRYPTION_KEY is not set. Patient PII will not be encrypted. Set ENCRYPTION_KEY before deploying to production.',
+    );
   }
 
   return validatedConfig;


### PR DESCRIPTION
## Summary
- Make `ENCRYPTION_KEY` required in production with minimum 32 characters
- Add `@MinLength(32)` validation to JWT secrets
- Make `REDIS_URL` required in production
- Add startup warning when `ENCRYPTION_KEY` is missing in development

## Changes
- `ENCRYPTION_KEY`: `@IsOptional()` → `@ValidateIf(NODE_ENV === 'production') @MinLength(32)`
- `REDIS_URL`: `@IsOptional()` → `@ValidateIf(NODE_ENV === 'production')`
- `JWT_ACCESS_SECRET`: Added `@MinLength(32)`
- `JWT_REFRESH_SECRET`: Added `@MinLength(32)`
- Added development warning for missing `ENCRYPTION_KEY`

## Test plan
- [ ] App starts in development without ENCRYPTION_KEY (with warning)
- [ ] App refuses to start in production without ENCRYPTION_KEY
- [ ] Weak JWT secrets (< 32 chars) rejected at startup
- [ ] Missing REDIS_URL rejected in production

Closes #188