### PR TITLE
Fix AdmissionStatus enum mismatch between schema and DTOs

### DIFF
--- a/apps/backend/src/modules/admission/admission.controller.ts
+++ b/apps/backend/src/modules/admission/admission.controller.ts
@@ -98,7 +98,7 @@ export class AdmissionController {
     name: 'status',
     description: 'Filter by admission status',
     required: false,
-    enum: ['ADMITTED', 'DISCHARGED', 'TRANSFERRED'],
+    enum: ['ACTIVE', 'DISCHARGED', 'TRANSFERRED'],
   })
   @ApiResponse({
     status: 200,

--- a/apps/backend/src/modules/admission/dto/admission-response.dto.ts
+++ b/apps/backend/src/modules/admission/dto/admission-response.dto.ts
@@ -111,7 +111,7 @@ export class AdmissionResponseDto {
   @ApiPropertyOptional({ description: 'Primary nurse ID', nullable: true })
   primaryNurseId: string | null;
 
-  @ApiProperty({ description: 'Admission status', enum: ['ADMITTED', 'DISCHARGED', 'TRANSFERRED'] })
+  @ApiProperty({ description: 'Admission status', enum: ['ACTIVE', 'DISCHARGED', 'TRANSFERRED'] })
   status: AdmissionStatus;
 
   @ApiPropertyOptional({ description: 'Expected discharge date', nullable: true })

--- a/apps/backend/src/modules/admission/dto/find-admissions.dto.ts
+++ b/apps/backend/src/modules/admission/dto/find-admissions.dto.ts
@@ -35,7 +35,7 @@ export class FindAdmissionsDto {
 
   @ApiPropertyOptional({
     description: 'Filter by admission status',
-    enum: ['ADMITTED', 'DISCHARGED', 'TRANSFERRED'],
+    enum: ['ACTIVE', 'DISCHARGED', 'TRANSFERRED'],
   })
   @IsOptional()
   @IsEnum(AdmissionStatus)

--- a/apps/frontend/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/patients/[id]/page.tsx
@@ -44,7 +44,7 @@ function formatGender(gender: Gender): string {
 
 function getStatusBadgeVariant(status: AdmissionStatus) {
   switch (status) {
-    case 'ADMITTED':
+    case 'ACTIVE':
       return 'success';
     case 'DISCHARGED':
       return 'secondary';
@@ -57,8 +57,8 @@ function getStatusBadgeVariant(status: AdmissionStatus) {
 
 function formatAdmissionStatus(status: AdmissionStatus): string {
   switch (status) {
-    case 'ADMITTED':
-      return 'Admitted';
+    case 'ACTIVE':
+      return 'Active';
     case 'DISCHARGED':
       return 'Discharged';
     case 'TRANSFERRED':
@@ -104,7 +104,7 @@ export default function PatientDetailPage({ params }: PatientDetailPageProps) {
     );
   }
 
-  const currentAdmission = admissions?.find((a) => a.status === 'ADMITTED');
+  const currentAdmission = admissions?.find((a) => a.status === 'ACTIVE');
 
   return (
     <div className="container mx-auto py-6 space-y-6">

--- a/apps/frontend/src/types/admission.ts
+++ b/apps/frontend/src/types/admission.ts
@@ -1,5 +1,5 @@
 export type AdmissionType = 'EMERGENCY' | 'SCHEDULED' | 'TRANSFER';
-export type AdmissionStatus = 'ADMITTED' | 'TRANSFERRED' | 'DISCHARGED';
+export type AdmissionStatus = 'ACTIVE' | 'TRANSFERRED' | 'DISCHARGED';
 export type DischargeType = 'NORMAL' | 'TRANSFER' | 'ESCAPE' | 'DEATH';
 
 export interface Transfer {


### PR DESCRIPTION
## Summary
- Replace hardcoded `ADMITTED` with `ACTIVE` in Swagger annotations, DTOs, frontend types, and UI components
- Aligns all AdmissionStatus references to match the Prisma schema enum definition (`ACTIVE`, `DISCHARGED`, `TRANSFERRED`)

Closes #189

## Changes
- **Backend**: Updated `@ApiQuery` and `@ApiProperty` enum arrays in `admission.controller.ts`, `find-admissions.dto.ts`, `admission-response.dto.ts`
- **Frontend**: Updated `AdmissionStatus` type in `admission.ts` and all references in patient detail page

## Test Plan
- [ ] Status filtering by `ACTIVE` returns correct results
- [ ] Swagger documentation shows correct enum values
- [ ] Frontend admission status badges display correctly