### PR TITLE
Implement main navigation layout with sidebar and header

### DIFF
--- a/apps/frontend/src/components/layouts/header.tsx
+++ b/apps/frontend/src/components/layouts/header.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Menu, LogOut, Building2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { useAuthStore } from '@/stores/auth-store';
+
+interface HeaderProps {
+  onMenuToggle: () => void;
+}
+
+function formatRole(role: string): string {
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+export function Header({ onMenuToggle }: HeaderProps) {
+  const router = useRouter();
+  const { user, logout } = useAuthStore();
+  const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const handleLogout = async () => {
+    setIsLoggingOut(true);
+    try {
+      await logout();
+      router.push('/login');
+    } finally {
+      setIsLoggingOut(false);
+      setShowLogoutDialog(false);
+    }
+  };
+
+  return (
+    <>
+      <header className="sticky top-0 z-40 flex h-16 items-center gap-4 border-b bg-background px-4 lg:px-6">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="lg:hidden"
+          onClick={onMenuToggle}
+          aria-label="Toggle navigation"
+        >
+          <Menu className="h-5 w-5" />
+        </Button>
+
+        <div className="flex items-center gap-2">
+          <Building2 className="h-6 w-6 text-primary" />
+          <span className="text-lg font-semibold hidden sm:inline-block">Hospital ERP</span>
+        </div>
+
+        <div className="flex-1" />
+
+        {user && (
+          <div className="flex items-center gap-3">
+            <div className="hidden sm:flex flex-col items-end text-sm">
+              <span className="font-medium">{user.name}</span>
+              <Badge variant="outline" className="text-xs">
+                {formatRole(user.role)}
+              </Badge>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowLogoutDialog(true)}
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <LogOut className="h-4 w-4" />
+              <span className="ml-2 hidden sm:inline">Logout</span>
+            </Button>
+          </div>
+        )}
+      </header>
+
+      <Dialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
+        <DialogContent className={cn('sm:max-w-md')}>
+          <DialogHeader>
+            <DialogTitle>Confirm Logout</DialogTitle>
+            <DialogDescription>Are you sure you want to log out of the system?</DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setShowLogoutDialog(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleLogout} disabled={isLoggingOut}>
+              {isLoggingOut ? 'Logging out...' : 'Logout'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/frontend/src/components/layouts/index.ts
+++ b/apps/frontend/src/components/layouts/index.ts
@@ -1,1 +1,3 @@
 export { MainLayout } from './main-layout';
+export { Header } from './header';
+export { Sidebar } from './sidebar';

--- a/apps/frontend/src/components/layouts/main-layout.tsx
+++ b/apps/frontend/src/components/layouts/main-layout.tsx
@@ -1,11 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { useAuthStore } from '@/stores/auth-store';
+import { Header } from './header';
+import { Sidebar } from './sidebar';
+
 interface MainLayoutProps {
   children: React.ReactNode;
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
+  const { user } = useAuthStore();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-background">
-      <main className="flex-1">{children}</main>
+      <Header onMenuToggle={() => setSidebarOpen(true)} />
+
+      <div className="flex">
+        {/* Desktop sidebar */}
+        <aside
+          className={cn(
+            'hidden lg:flex lg:w-60 lg:flex-col lg:fixed lg:inset-y-0 lg:top-16',
+            'border-r bg-background',
+          )}
+        >
+          <div className="flex flex-1 flex-col overflow-y-auto pt-2">
+            <Sidebar userRole={user?.role} />
+          </div>
+        </aside>
+
+        {/* Mobile sidebar */}
+        <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+          <SheetContent side="left" className="w-60 p-0 pt-10">
+            <SheetTitle className="sr-only">Navigation</SheetTitle>
+            <Sidebar userRole={user?.role} onNavigate={() => setSidebarOpen(false)} />
+          </SheetContent>
+        </Sheet>
+
+        {/* Main content */}
+        <main className="flex-1 lg:pl-60">
+          <div className="p-4 lg:p-6">{children}</div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/components/layouts/sidebar.tsx
+++ b/apps/frontend/src/components/layouts/sidebar.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  LayoutDashboard,
+  Users,
+  BedDouble,
+  ClipboardList,
+  FileText,
+  Activity,
+  Pill,
+  NotebookPen,
+  Droplets,
+  FileBarChart,
+  Settings,
+  UserCog,
+  Shield,
+  ScrollText,
+  ChevronDown,
+} from 'lucide-react';
+import { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import type { UserRole } from '@/types';
+
+interface NavItem {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  roles?: UserRole[];
+  children?: NavItem[];
+}
+
+const navItems: NavItem[] = [
+  {
+    label: 'Dashboard',
+    href: '/',
+    icon: LayoutDashboard,
+  },
+  {
+    label: 'Patients',
+    href: '/patients',
+    icon: Users,
+  },
+  {
+    label: 'Rooms',
+    href: '/rooms',
+    icon: BedDouble,
+  },
+  {
+    label: 'Rounding',
+    href: '/rounding',
+    icon: ClipboardList,
+  },
+  {
+    label: 'Reports',
+    href: '/reports',
+    icon: FileText,
+    children: [
+      { label: 'Vital Signs', href: '/reports/vital-signs', icon: Activity },
+      { label: 'Medications', href: '/reports/medications', icon: Pill },
+      { label: 'Nursing Notes', href: '/reports/nursing-notes', icon: NotebookPen },
+      { label: 'Intake/Output', href: '/reports/intake-output', icon: Droplets },
+      { label: 'Daily Reports', href: '/reports/daily-reports', icon: FileBarChart },
+    ],
+  },
+  {
+    label: 'Admin',
+    href: '/admin',
+    icon: Settings,
+    roles: ['admin'],
+    children: [
+      { label: 'Users', href: '/admin/users', icon: UserCog },
+      { label: 'Roles', href: '/admin/roles', icon: Shield },
+      { label: 'Audit Logs', href: '/admin/audit-logs', icon: ScrollText },
+    ],
+  },
+];
+
+interface SidebarProps {
+  userRole?: UserRole;
+  onNavigate?: () => void;
+}
+
+export function Sidebar({ userRole, onNavigate }: SidebarProps) {
+  const pathname = usePathname();
+
+  const filteredItems = navItems.filter(
+    (item) => !item.roles || (userRole && item.roles.includes(userRole)),
+  );
+
+  return (
+    <nav className="flex flex-col gap-1 p-3">
+      {filteredItems.map((item) => (
+        <NavItemComponent key={item.href} item={item} pathname={pathname} onNavigate={onNavigate} />
+      ))}
+    </nav>
+  );
+}
+
+function NavItemComponent({
+  item,
+  pathname,
+  onNavigate,
+}: {
+  item: NavItem;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const isActive = pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href));
+  const hasChildren = item.children && item.children.length > 0;
+  const isChildActive =
+    hasChildren && item.children!.some((child) => pathname.startsWith(child.href));
+  const [isOpen, setIsOpen] = useState(isChildActive);
+
+  if (hasChildren) {
+    return (
+      <div>
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className={cn(
+            'flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+            isActive || isChildActive
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+          )}
+        >
+          <item.icon className="h-4 w-4 shrink-0" />
+          <span className="flex-1 text-left">{item.label}</span>
+          <ChevronDown
+            className={cn('h-4 w-4 shrink-0 transition-transform', isOpen && 'rotate-180')}
+          />
+        </button>
+        {isOpen && (
+          <div className="ml-4 mt-1 flex flex-col gap-1 border-l pl-3">
+            {item.children!.map((child) => {
+              const childActive = pathname.startsWith(child.href);
+              return (
+                <Link
+                  key={child.href}
+                  href={child.href}
+                  onClick={onNavigate}
+                  className={cn(
+                    'flex items-center gap-3 rounded-md px-3 py-1.5 text-sm transition-colors',
+                    childActive
+                      ? 'bg-primary/10 text-primary font-medium'
+                      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                  )}
+                >
+                  <child.icon className="h-3.5 w-3.5 shrink-0" />
+                  <span>{child.label}</span>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={item.href}
+      onClick={onNavigate}
+      className={cn(
+        'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors',
+        isActive
+          ? 'bg-primary/10 text-primary'
+          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+      )}
+    >
+      <item.icon className="h-4 w-4 shrink-0" />
+      <span>{item.label}</span>
+    </Link>
+  );
+}

--- a/apps/frontend/src/components/ui/index.ts
+++ b/apps/frontend/src/components/ui/index.ts
@@ -48,3 +48,15 @@ export {
   DialogDescription,
 } from './dialog';
 export { Textarea } from './textarea';
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+} from './sheet';

--- a/apps/frontend/src/components/ui/sheet.tsx
+++ b/apps/frontend/src/components/ui/sheet.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+);
+
+interface SheetContentProps
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    {...props}
+  />
+);
+SheetFooter.displayName = 'SheetFooter';
+
+const SheetTitle = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ComponentRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};


### PR DESCRIPTION
## Summary
- Add Header component with app logo, user info display (name + role badge), and logout with confirmation dialog
- Add Sidebar navigation with all major sections: Dashboard, Patients, Rooms, Rounding, Reports (sub-menu), Admin (admin-only sub-menu)
- Add shadcn Sheet component for responsive mobile sidebar
- Update MainLayout to integrate fixed desktop sidebar (240px) with responsive mobile drawer
- Role-based menu visibility (Admin section only visible to admin users)
- Active route highlighting with collapsible sub-menus

Closes #190

## Changes
- **New**: `components/ui/sheet.tsx` - shadcn Sheet component (built on @radix-ui/react-dialog)
- **New**: `components/layouts/sidebar.tsx` - Sidebar with nav items, role filtering, sub-menus
- **New**: `components/layouts/header.tsx` - Header with user menu and logout
- **Modified**: `components/layouts/main-layout.tsx` - Integrated sidebar + header layout
- **Modified**: `components/layouts/index.ts` - Export new components
- **Modified**: `components/ui/index.ts` - Export Sheet component

## Test Plan
- [ ] Desktop: sidebar visible at 1024px+, navigation works
- [ ] Mobile/Tablet: hamburger menu opens sheet sidebar
- [ ] Logout button shows confirmation dialog
- [ ] Admin menu hidden for non-admin users
- [ ] Active route highlighted in sidebar
- [ ] Sub-menus (Reports, Admin) collapse/expand correctly