### PR TITLE
feat(admin): add user management and audit log pages

### DIFF
--- a/apps/frontend/src/app/(dashboard)/admin/audit-logs/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/audit-logs/page.tsx
@@ -1,0 +1,434 @@
+'use client';
+
+import { useState } from 'react';
+import { useLoginHistory, useAccessLogs, useChangeLogs } from '@/hooks';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Button,
+  Badge,
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+  LegacySelect,
+  Skeleton,
+} from '@/components/ui';
+import { ChevronLeft, ChevronRight, History, FileText, Database } from 'lucide-react';
+import type { AuditAction } from '@/types';
+
+type TabType = 'login' | 'access' | 'change';
+
+const actionOptions = [
+  { value: '', label: 'All Actions' },
+  { value: 'CREATE', label: 'Create' },
+  { value: 'READ', label: 'Read' },
+  { value: 'UPDATE', label: 'Update' },
+  { value: 'DELETE', label: 'Delete' },
+];
+
+const loginStatusOptions = [
+  { value: '', label: 'All' },
+  { value: 'true', label: 'Success' },
+  { value: 'false', label: 'Failed' },
+];
+
+function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+function getDefaultDateRange(): { startDate: string; endDate: string } {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - 7);
+  return {
+    startDate: start.toISOString().split('T')[0],
+    endDate: end.toISOString().split('T')[0],
+  };
+}
+
+export default function AuditLogsPage() {
+  const [activeTab, setActiveTab] = useState<TabType>('login');
+  const [page, setPage] = useState(1);
+  const limit = 20;
+
+  const defaultDates = getDefaultDateRange();
+  const [startDate, setStartDate] = useState(defaultDates.startDate);
+  const [endDate, setEndDate] = useState(defaultDates.endDate);
+  const [loginSuccess, setLoginSuccess] = useState('');
+  const [accessAction, setAccessAction] = useState('');
+  const [changeAction, setChangeAction] = useState('');
+  const [changeTable, setChangeTable] = useState('');
+
+  const loginHistory = useLoginHistory({
+    success: loginSuccess ? loginSuccess === 'true' : undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    page,
+    limit,
+  });
+
+  const accessLogs = useAccessLogs({
+    action: (accessAction as AuditAction) || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    page,
+    limit,
+  });
+
+  const changeLogs = useChangeLogs({
+    tableName: changeTable || undefined,
+    action: (changeAction as AuditAction) || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    page,
+    limit,
+  });
+
+  const handleTabChange = (tab: TabType) => {
+    setActiveTab(tab);
+    setPage(1);
+  };
+
+  const tabs = [
+    { id: 'login' as const, label: 'Login History', icon: History },
+    { id: 'access' as const, label: 'Access Logs', icon: FileText },
+    { id: 'change' as const, label: 'Change Logs', icon: Database },
+  ];
+
+  const getCurrentData = () => {
+    switch (activeTab) {
+      case 'login':
+        return loginHistory;
+      case 'access':
+        return accessLogs;
+      case 'change':
+        return changeLogs;
+    }
+  };
+
+  const currentQuery = getCurrentData();
+  const totalPages = currentQuery.data?.totalPages ?? 0;
+  const total = currentQuery.data?.total ?? 0;
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <h1 className="text-2xl font-bold">Audit Logs</h1>
+
+      {/* Tab Navigation */}
+      <div className="flex gap-2 border-b">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => handleTabChange(tab.id)}
+            className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
+              activeTab === tab.id
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            <tab.icon className="h-4 w-4" />
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Filters */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">Start Date</label>
+              <Input
+                type="date"
+                value={startDate}
+                onChange={(e) => {
+                  setStartDate(e.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-muted-foreground">End Date</label>
+              <Input
+                type="date"
+                value={endDate}
+                onChange={(e) => {
+                  setEndDate(e.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+            {activeTab === 'login' && (
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Status</label>
+                <LegacySelect
+                  options={loginStatusOptions}
+                  value={loginSuccess}
+                  onChange={(e) => {
+                    setLoginSuccess(e.target.value);
+                    setPage(1);
+                  }}
+                />
+              </div>
+            )}
+            {activeTab === 'access' && (
+              <div className="space-y-1">
+                <label className="text-xs text-muted-foreground">Action</label>
+                <LegacySelect
+                  options={actionOptions}
+                  value={accessAction}
+                  onChange={(e) => {
+                    setAccessAction(e.target.value);
+                    setPage(1);
+                  }}
+                />
+              </div>
+            )}
+            {activeTab === 'change' && (
+              <>
+                <div className="space-y-1">
+                  <label className="text-xs text-muted-foreground">Action</label>
+                  <LegacySelect
+                    options={actionOptions}
+                    value={changeAction}
+                    onChange={(e) => {
+                      setChangeAction(e.target.value);
+                      setPage(1);
+                    }}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs text-muted-foreground">Table Name</label>
+                  <Input
+                    placeholder="e.g. patients"
+                    value={changeTable}
+                    onChange={(e) => {
+                      setChangeTable(e.target.value);
+                      setPage(1);
+                    }}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Data Table */}
+      <Card>
+        <CardContent className="p-0">
+          {currentQuery.isLoading ? (
+            <div className="p-6 space-y-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : currentQuery.error ? (
+            <div className="p-6 text-center text-destructive">
+              Failed to load audit logs. Please try again.
+            </div>
+          ) : (currentQuery.data?.data.length ?? 0) === 0 ? (
+            <div className="p-6 text-center text-muted-foreground">No logs found.</div>
+          ) : (
+            <>
+              {activeTab === 'login' && loginHistory.data && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Username</TableHead>
+                      <TableHead>IP Address</TableHead>
+                      <TableHead>Device</TableHead>
+                      <TableHead>Browser / OS</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Login Time</TableHead>
+                      <TableHead>Failure Reason</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {loginHistory.data.data.map((log) => (
+                      <TableRow key={log.id}>
+                        <TableCell className="font-medium">{log.username}</TableCell>
+                        <TableCell className="font-mono text-xs">{log.ipAddress}</TableCell>
+                        <TableCell>{log.deviceType || '-'}</TableCell>
+                        <TableCell className="text-xs">
+                          {[log.browser, log.os].filter(Boolean).join(' / ') || '-'}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant={log.success ? 'default' : 'destructive'}>
+                            {log.success ? 'Success' : 'Failed'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-sm">{formatDateTime(log.loginAt)}</TableCell>
+                        <TableCell className="text-xs text-muted-foreground">
+                          {log.failureReason || '-'}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+
+              {activeTab === 'access' && accessLogs.data && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Username</TableHead>
+                      <TableHead>Action</TableHead>
+                      <TableHead>Resource</TableHead>
+                      <TableHead>Method / Path</TableHead>
+                      <TableHead>IP Address</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Time</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {accessLogs.data.data.map((log) => (
+                      <TableRow key={log.id}>
+                        <TableCell className="font-medium">{log.username}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              log.action === 'DELETE'
+                                ? 'destructive'
+                                : log.action === 'CREATE'
+                                  ? 'default'
+                                  : 'secondary'
+                            }
+                          >
+                            {log.action}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          {log.resourceType}
+                          {log.resourceId && (
+                            <span className="text-xs text-muted-foreground ml-1">
+                              #{log.resourceId}
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {log.requestMethod} {log.requestPath}
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">{log.ipAddress}</TableCell>
+                        <TableCell>
+                          <Badge variant={log.success ? 'default' : 'destructive'}>
+                            {log.success ? 'OK' : log.errorCode || 'Error'}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-sm">{formatDateTime(log.createdAt)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+
+              {activeTab === 'change' && changeLogs.data && (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Username</TableHead>
+                      <TableHead>Action</TableHead>
+                      <TableHead>Table</TableHead>
+                      <TableHead>Record ID</TableHead>
+                      <TableHead>Changed Fields</TableHead>
+                      <TableHead>Reason</TableHead>
+                      <TableHead>Time</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {changeLogs.data.data.map((log) => (
+                      <TableRow key={log.id}>
+                        <TableCell className="font-medium">{log.username}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              log.action === 'DELETE'
+                                ? 'destructive'
+                                : log.action === 'CREATE'
+                                  ? 'default'
+                                  : 'secondary'
+                            }
+                          >
+                            {log.action}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="font-mono text-xs">{log.tableName}</TableCell>
+                        <TableCell className="font-mono text-xs">{log.recordId}</TableCell>
+                        <TableCell>
+                          <div className="flex gap-1 flex-wrap max-w-48">
+                            {log.changedFields.slice(0, 3).map((field) => (
+                              <Badge key={field} variant="outline" className="text-xs">
+                                {field}
+                              </Badge>
+                            ))}
+                            {log.changedFields.length > 3 && (
+                              <Badge variant="outline" className="text-xs">
+                                +{log.changedFields.length - 3}
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-xs text-muted-foreground max-w-32 truncate">
+                          {log.changeReason || '-'}
+                        </TableCell>
+                        <TableCell className="text-sm">{formatDateTime(log.createdAt)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, total)} of {total} records
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(page - 1)}
+              disabled={page <= 1}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Previous
+            </Button>
+            <span className="text-sm">
+              Page {page} of {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(page + 1)}
+              disabled={page >= totalPages}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(dashboard)/admin/layout.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/layout.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useAuthStore } from '@/stores/auth-store';
+import { Card, CardContent } from '@/components/ui';
+import { ShieldAlert } from 'lucide-react';
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const user = useAuthStore((s) => s.user);
+
+  if (user?.role !== 'admin') {
+    return (
+      <div className="container mx-auto py-12">
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <ShieldAlert className="h-12 w-12 text-destructive" />
+            <h2 className="text-xl font-semibold">Access Denied</h2>
+            <p className="text-muted-foreground">
+              You do not have permission to access the admin area.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/frontend/src/app/(dashboard)/admin/users/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/admin/users/page.tsx
@@ -1,0 +1,451 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  useAdminUsers,
+  useCreateUser,
+  useDeactivateUser,
+  useResetPassword,
+  useRoles,
+} from '@/hooks';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Button,
+  Badge,
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+  LegacySelect,
+  Skeleton,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  Label,
+} from '@/components/ui';
+import { Search, ChevronLeft, ChevronRight, UserPlus, RotateCcw, UserX, Copy } from 'lucide-react';
+import { useDebounce } from '@/hooks';
+import type { ListUsersParams, CreateUserData } from '@/types';
+
+const statusOptions = [
+  { value: '', label: 'All Status' },
+  { value: 'true', label: 'Active' },
+  { value: 'false', label: 'Inactive' },
+];
+
+function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export default function AdminUsersPage() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isActive, setIsActive] = useState('');
+  const [page, setPage] = useState(1);
+  const limit = 20;
+
+  const debouncedSearch = useDebounce(searchQuery, 300);
+
+  const params: ListUsersParams = {
+    search: debouncedSearch || undefined,
+    isActive: isActive ? isActive === 'true' : undefined,
+    page,
+    limit,
+  };
+
+  const { data, isLoading, error } = useAdminUsers(params);
+  const { data: roles } = useRoles();
+  const createUser = useCreateUser();
+  const deactivateUser = useDeactivateUser();
+  const resetPassword = useResetPassword();
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showPasswordDialog, setShowPasswordDialog] = useState(false);
+  const [temporaryPassword, setTemporaryPassword] = useState('');
+  const [confirmDeactivateId, setConfirmDeactivateId] = useState<string | null>(null);
+
+  const [newUser, setNewUser] = useState<CreateUserData>({
+    employeeId: '',
+    username: '',
+    name: '',
+    email: '',
+    phone: '',
+    department: '',
+    position: '',
+    roleIds: [],
+  });
+
+  const handleCreateUser = async () => {
+    try {
+      const result = await createUser.mutateAsync(newUser);
+      setTemporaryPassword(result.temporaryPassword);
+      setShowCreateDialog(false);
+      setShowPasswordDialog(true);
+      setNewUser({
+        employeeId: '',
+        username: '',
+        name: '',
+        email: '',
+        phone: '',
+        department: '',
+        position: '',
+        roleIds: [],
+      });
+    } catch {
+      // Error handled by mutation
+    }
+  };
+
+  const handleResetPassword = async (userId: string) => {
+    try {
+      const result = await resetPassword.mutateAsync(userId);
+      setTemporaryPassword(result.temporaryPassword);
+      setShowPasswordDialog(true);
+    } catch {
+      // Error handled by mutation
+    }
+  };
+
+  const handleDeactivate = async (userId: string) => {
+    try {
+      await deactivateUser.mutateAsync(userId);
+      setConfirmDeactivateId(null);
+    } catch {
+      // Error handled by mutation
+    }
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">User Management</h1>
+        <Button onClick={() => setShowCreateDialog(true)}>
+          <UserPlus className="h-4 w-4 mr-2" />
+          Create User
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Search and Filter</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Search by name, username, or employee ID..."
+                value={searchQuery}
+                onChange={(e) => {
+                  setSearchQuery(e.target.value);
+                  setPage(1);
+                }}
+                className="pl-9"
+              />
+            </div>
+            <div className="w-full md:w-40">
+              <LegacySelect
+                options={statusOptions}
+                value={isActive}
+                onChange={(e) => {
+                  setIsActive(e.target.value);
+                  setPage(1);
+                }}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-6 space-y-4">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : error ? (
+            <div className="p-6 text-center text-destructive">
+              Failed to load users. Please try again.
+            </div>
+          ) : data?.data.length === 0 ? (
+            <div className="p-6 text-center text-muted-foreground">No users found.</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Employee ID</TableHead>
+                  <TableHead>Username</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Department</TableHead>
+                  <TableHead>Roles</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Login</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data?.data.map((user) => (
+                  <TableRow key={user.id}>
+                    <TableCell className="font-mono text-sm">{user.employeeId}</TableCell>
+                    <TableCell>{user.username}</TableCell>
+                    <TableCell className="font-medium">{user.name}</TableCell>
+                    <TableCell>{user.department || '-'}</TableCell>
+                    <TableCell>
+                      <div className="flex gap-1 flex-wrap">
+                        {user.roles.map((role) => (
+                          <Badge key={role.id} variant="outline" className="text-xs">
+                            {role.name}
+                          </Badge>
+                        ))}
+                        {user.roles.length === 0 && (
+                          <span className="text-xs text-muted-foreground">No roles</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={user.isActive ? 'default' : 'destructive'}>
+                        {user.isActive ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {user.lastLoginAt ? formatDateTime(user.lastLoginAt) : 'Never'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          title="Reset Password"
+                          onClick={() => handleResetPassword(user.id)}
+                          disabled={resetPassword.isPending}
+                        >
+                          <RotateCcw className="h-4 w-4" />
+                        </Button>
+                        {user.isActive && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            title="Deactivate"
+                            onClick={() => setConfirmDeactivateId(user.id)}
+                          >
+                            <UserX className="h-4 w-4 text-destructive" />
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {data && data.meta.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {(page - 1) * limit + 1} to {Math.min(page * limit, data.meta.total)} of{' '}
+            {data.meta.total} users
+          </p>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(page - 1)}
+              disabled={!data.meta.hasPrevPage}
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Previous
+            </Button>
+            <span className="text-sm">
+              Page {page} of {data.meta.totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage(page + 1)}
+              disabled={!data.meta.hasNextPage}
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Create User Dialog */}
+      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Create New User</DialogTitle>
+            <DialogDescription>
+              Fill in the details below to create a new user account.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Employee ID *</Label>
+                <Input
+                  value={newUser.employeeId}
+                  onChange={(e) => setNewUser({ ...newUser, employeeId: e.target.value })}
+                  placeholder="EMP001"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Username *</Label>
+                <Input
+                  value={newUser.username}
+                  onChange={(e) => setNewUser({ ...newUser, username: e.target.value })}
+                  placeholder="johndoe"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Name *</Label>
+              <Input
+                value={newUser.name}
+                onChange={(e) => setNewUser({ ...newUser, name: e.target.value })}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Email</Label>
+                <Input
+                  type="email"
+                  value={newUser.email}
+                  onChange={(e) => setNewUser({ ...newUser, email: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Phone</Label>
+                <Input
+                  value={newUser.phone}
+                  onChange={(e) => setNewUser({ ...newUser, phone: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label>Department</Label>
+                <Input
+                  value={newUser.department}
+                  onChange={(e) => setNewUser({ ...newUser, department: e.target.value })}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Position</Label>
+                <Input
+                  value={newUser.position}
+                  onChange={(e) => setNewUser({ ...newUser, position: e.target.value })}
+                />
+              </div>
+            </div>
+            {roles && roles.length > 0 && (
+              <div className="space-y-2">
+                <Label>Roles</Label>
+                <div className="flex flex-wrap gap-2">
+                  {roles.map((role) => (
+                    <Badge
+                      key={role.id}
+                      variant={newUser.roleIds.includes(role.id) ? 'default' : 'outline'}
+                      className="cursor-pointer"
+                      onClick={() => {
+                        setNewUser({
+                          ...newUser,
+                          roleIds: newUser.roleIds.includes(role.id)
+                            ? newUser.roleIds.filter((r) => r !== role.id)
+                            : [...newUser.roleIds, role.id],
+                        });
+                      }}
+                    >
+                      {role.name}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleCreateUser}
+              disabled={
+                !newUser.employeeId || !newUser.username || !newUser.name || createUser.isPending
+              }
+            >
+              {createUser.isPending ? 'Creating...' : 'Create'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Temporary Password Dialog */}
+      <Dialog open={showPasswordDialog} onOpenChange={setShowPasswordDialog}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Temporary Password</DialogTitle>
+            <DialogDescription>
+              Please save this password. It will not be shown again.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex items-center gap-2 p-3 bg-muted rounded-md">
+            <code className="flex-1 text-lg font-mono">{temporaryPassword}</code>
+            <Button variant="ghost" size="sm" onClick={() => copyToClipboard(temporaryPassword)}>
+              <Copy className="h-4 w-4" />
+            </Button>
+          </div>
+          <DialogFooter>
+            <Button onClick={() => setShowPasswordDialog(false)}>Done</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Confirm Deactivate Dialog */}
+      <Dialog open={!!confirmDeactivateId} onOpenChange={() => setConfirmDeactivateId(null)}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Deactivate User</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to deactivate this user? They will no longer be able to log in.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDeactivateId(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => confirmDeactivateId && handleDeactivate(confirmDeactivateId)}
+              disabled={deactivateUser.isPending}
+            >
+              {deactivateUser.isPending ? 'Deactivating...' : 'Deactivate'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -36,3 +36,17 @@ export {
 } from './use-medications';
 export { useNursingNotes, useSignificantNotes, useCreateNursingNote } from './use-nursing-notes';
 export { useIOHistory, useIODailySummary, useRecordIO } from './use-intake-output';
+export {
+  useAdminUsers,
+  useAdminUser,
+  useCreateUser,
+  useUpdateUser,
+  useDeactivateUser,
+  useResetPassword,
+  useAssignRole,
+  useRemoveRole,
+  useRoles,
+  useLoginHistory,
+  useAccessLogs,
+  useChangeLogs,
+} from './use-admin';

--- a/apps/frontend/src/hooks/use-admin.ts
+++ b/apps/frontend/src/hooks/use-admin.ts
@@ -1,0 +1,120 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { adminUserApi, adminRoleApi, adminAuditApi } from '@/services';
+import type {
+  ListUsersParams,
+  CreateUserData,
+  UpdateUserData,
+  QueryLoginHistoryParams,
+  QueryAccessLogsParams,
+  QueryChangeLogsParams,
+} from '@/types';
+
+// User hooks
+export function useAdminUsers(params: ListUsersParams = {}) {
+  return useQuery({
+    queryKey: ['admin-users', params],
+    queryFn: () => adminUserApi.list(params),
+  });
+}
+
+export function useAdminUser(id: string) {
+  return useQuery({
+    queryKey: ['admin-user', id],
+    queryFn: () => adminUserApi.getById(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateUserData) => adminUserApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+  });
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateUserData }) =>
+      adminUserApi.update(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+  });
+}
+
+export function useDeactivateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => adminUserApi.deactivate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+  });
+}
+
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: (id: string) => adminUserApi.resetPassword(id),
+  });
+}
+
+export function useAssignRole() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ userId, roleId }: { userId: string; roleId: string }) =>
+      adminUserApi.assignRole(userId, roleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+  });
+}
+
+export function useRemoveRole() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ userId, roleId }: { userId: string; roleId: string }) =>
+      adminUserApi.removeRole(userId, roleId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin-users'] });
+    },
+  });
+}
+
+// Role hooks
+export function useRoles() {
+  return useQuery({
+    queryKey: ['admin-roles'],
+    queryFn: () => adminRoleApi.list(),
+  });
+}
+
+// Audit hooks
+export function useLoginHistory(params: QueryLoginHistoryParams = {}) {
+  return useQuery({
+    queryKey: ['audit-login-history', params],
+    queryFn: () => adminAuditApi.loginHistory(params),
+  });
+}
+
+export function useAccessLogs(params: QueryAccessLogsParams = {}) {
+  return useQuery({
+    queryKey: ['audit-access-logs', params],
+    queryFn: () => adminAuditApi.accessLogs(params),
+  });
+}
+
+export function useChangeLogs(params: QueryChangeLogsParams = {}) {
+  return useQuery({
+    queryKey: ['audit-change-logs', params],
+    queryFn: () => adminAuditApi.changeLogs(params),
+  });
+}

--- a/apps/frontend/src/services/admin-api.ts
+++ b/apps/frontend/src/services/admin-api.ts
@@ -1,0 +1,105 @@
+import { apiGet, apiPost, apiPatch, apiDelete } from '@/lib/api-client';
+import type {
+  AdminUser,
+  PaginatedUsers,
+  CreateUserData,
+  CreateUserResponse,
+  UpdateUserData,
+  ResetPasswordResponse,
+  ListUsersParams,
+  Role,
+  LoginHistory,
+  AccessLog,
+  ChangeLog,
+  PaginatedAudit,
+  QueryLoginHistoryParams,
+  QueryAccessLogsParams,
+  QueryChangeLogsParams,
+  SuspiciousActivity,
+} from '@/types';
+
+function buildQueryString(params: Record<string, unknown>): string {
+  const searchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      searchParams.set(key, String(value));
+    }
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export const adminUserApi = {
+  list: (params: ListUsersParams = {}): Promise<PaginatedUsers> => {
+    return apiGet<PaginatedUsers>(`/admin/users${buildQueryString(params)}`);
+  },
+
+  getById: (id: string): Promise<AdminUser> => {
+    return apiGet<AdminUser>(`/admin/users/${id}`);
+  },
+
+  create: (data: CreateUserData): Promise<CreateUserResponse> => {
+    return apiPost<CreateUserResponse>('/admin/users', data);
+  },
+
+  update: (id: string, data: UpdateUserData): Promise<AdminUser> => {
+    return apiPatch<AdminUser>(`/admin/users/${id}`, data);
+  },
+
+  deactivate: (id: string): Promise<void> => {
+    return apiDelete<void>(`/admin/users/${id}`);
+  },
+
+  resetPassword: (id: string): Promise<ResetPasswordResponse> => {
+    return apiPost<ResetPasswordResponse>(`/admin/users/${id}/reset-password`);
+  },
+
+  assignRole: (userId: string, roleId: string): Promise<{ message: string }> => {
+    return apiPost<{ message: string }>(`/admin/users/${userId}/roles`, { roleId });
+  },
+
+  removeRole: (userId: string, roleId: string): Promise<void> => {
+    return apiDelete<void>(`/admin/users/${userId}/roles/${roleId}`);
+  },
+};
+
+export const adminRoleApi = {
+  list: (): Promise<Role[]> => {
+    return apiGet<Role[]>('/admin/roles');
+  },
+};
+
+export const adminAuditApi = {
+  loginHistory: (params: QueryLoginHistoryParams = {}): Promise<PaginatedAudit<LoginHistory>> => {
+    return apiGet<PaginatedAudit<LoginHistory>>(
+      `/admin/audit/login-history${buildQueryString(params)}`,
+    );
+  },
+
+  accessLogs: (params: QueryAccessLogsParams = {}): Promise<PaginatedAudit<AccessLog>> => {
+    return apiGet<PaginatedAudit<AccessLog>>(`/admin/audit/access-logs${buildQueryString(params)}`);
+  },
+
+  changeLogs: (params: QueryChangeLogsParams = {}): Promise<PaginatedAudit<ChangeLog>> => {
+    return apiGet<PaginatedAudit<ChangeLog>>(`/admin/audit/change-logs${buildQueryString(params)}`);
+  },
+
+  suspiciousActivity: (startDate: string, endDate: string): Promise<SuspiciousActivity[]> => {
+    return apiGet<SuspiciousActivity[]>(
+      `/admin/audit/security/suspicious-activity?startDate=${startDate}&endDate=${endDate}`,
+    );
+  },
+
+  failedLogins: (
+    startDate: string,
+    endDate: string,
+    page = 1,
+    limit = 20,
+  ): Promise<PaginatedAudit<LoginHistory>> => {
+    return apiGet<PaginatedAudit<LoginHistory>>(
+      `/admin/audit/security/failed-logins?startDate=${startDate}&endDate=${endDate}&page=${page}&limit=${limit}`,
+    );
+  },
+};

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -7,3 +7,4 @@ export { roundingApi } from './rounding-api';
 export { medicationApi } from './medication-api';
 export { nursingNoteApi } from './nursing-note-api';
 export { intakeOutputApi } from './intake-output-api';
+export { adminUserApi, adminRoleApi, adminAuditApi } from './admin-api';

--- a/apps/frontend/src/types/admin.ts
+++ b/apps/frontend/src/types/admin.ts
@@ -1,0 +1,192 @@
+// User Management Types
+export interface AdminUser {
+  id: string;
+  employeeId: string;
+  username: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  department?: string;
+  position?: string;
+  isActive: boolean;
+  lastLoginAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  roles: RoleBasic[];
+}
+
+export interface RoleBasic {
+  id: string;
+  code: string;
+  name: string;
+}
+
+export interface Role extends RoleBasic {
+  description?: string;
+  level: number;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Permission {
+  id: string;
+  code: string;
+  resource: string;
+  action: string;
+  description?: string;
+}
+
+export interface RoleWithPermissions extends Role {
+  permissions: Permission[];
+}
+
+export interface CreateUserData {
+  employeeId: string;
+  username: string;
+  name: string;
+  email?: string;
+  phone?: string;
+  department?: string;
+  position?: string;
+  roleIds: string[];
+}
+
+export interface CreateUserResponse extends AdminUser {
+  temporaryPassword: string;
+}
+
+export interface UpdateUserData {
+  name?: string;
+  email?: string;
+  phone?: string;
+  department?: string;
+  position?: string;
+  isActive?: boolean;
+}
+
+export interface ListUsersParams {
+  search?: string;
+  department?: string;
+  isActive?: boolean;
+  roleId?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface PaginatedUsers {
+  data: AdminUser[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+  };
+}
+
+export interface ResetPasswordResponse {
+  temporaryPassword: string;
+  message: string;
+}
+
+// Audit Types
+export type AuditAction = 'CREATE' | 'READ' | 'UPDATE' | 'DELETE';
+export type DeviceType = 'PC' | 'TABLET' | 'MOBILE';
+
+export interface LoginHistory {
+  id: string;
+  userId: string | null;
+  username: string;
+  ipAddress: string;
+  userAgent: string | null;
+  deviceType: DeviceType | null;
+  browser: string | null;
+  os: string | null;
+  loginAt: string;
+  logoutAt: string | null;
+  sessionId: string | null;
+  success: boolean;
+  failureReason: string | null;
+}
+
+export interface AccessLog {
+  id: string;
+  userId: string;
+  username: string;
+  userRole: string | null;
+  ipAddress: string;
+  resourceType: string;
+  resourceId: string;
+  action: AuditAction;
+  requestPath: string | null;
+  requestMethod: string | null;
+  patientId: string | null;
+  accessedFields: string[];
+  success: boolean;
+  errorCode: string | null;
+  errorMessage: string | null;
+  createdAt: string;
+}
+
+export interface ChangeLog {
+  id: string;
+  userId: string;
+  username: string;
+  ipAddress: string | null;
+  tableSchema: string;
+  tableName: string;
+  recordId: string;
+  action: AuditAction;
+  oldValues: unknown;
+  newValues: unknown;
+  changedFields: string[];
+  changeReason: string | null;
+  createdAt: string;
+}
+
+export interface PaginatedAudit<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface QueryLoginHistoryParams {
+  userId?: string;
+  username?: string;
+  success?: boolean;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface QueryAccessLogsParams {
+  userId?: string;
+  action?: AuditAction;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface QueryChangeLogsParams {
+  userId?: string;
+  tableName?: string;
+  action?: AuditAction;
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}
+
+export interface SuspiciousActivity {
+  ipAddress: string;
+  failedAttempts: number;
+  usernames: string[];
+}

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -28,3 +28,4 @@ export * from './rounding';
 export * from './medication';
 export * from './nursing-note';
 export * from './intake-output';
+export * from './admin';


### PR DESCRIPTION
## Summary
- Add frontend types, API service layer, and React Query hooks for admin module
- Create user management page with search/filter, CRUD operations, password reset, and role display
- Create audit log page with tabbed view for login history, access logs, and change logs
- Add admin layout with role-based access guard (admin only)

## Changes
- `types/admin.ts` — AdminUser, Role, Permission, audit types, query params
- `services/admin-api.ts` — adminUserApi (8 methods), adminRoleApi, adminAuditApi (5 methods)
- `hooks/use-admin.ts` — 12 React Query hooks for users, roles, and audit data
- `admin/layout.tsx` — Role guard restricting access to admin users
- `admin/users/page.tsx` — User list with search, filter, create dialog, password reset, deactivate
- `admin/audit-logs/page.tsx` — Tabbed audit log viewer with date range filters

Closes #193