### PR TITLE
feat(admission): add admission, transfer, and discharge workflow

### DIFF
--- a/apps/frontend/src/app/(dashboard)/patients/[id]/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/patients/[id]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui';
 import {
   ArrowLeft,
+  ArrowRightLeft,
   User,
   Phone,
   MapPin,
@@ -33,11 +34,13 @@ import {
   Droplets,
   ChevronDown,
   ChevronUp,
+  LogOut,
 } from 'lucide-react';
 import { VitalSignsForm, VitalTrendChart, VitalAlerts } from '@/components/vital-signs';
 import { MedicationScheduleForm, MedicationList } from '@/components/medications';
 import { NursingNoteForm, NursingNoteList } from '@/components/nursing-notes';
 import { IORecordForm, IOHistory, IODailySummaryCard } from '@/components/intake-output';
+import { AdmissionForm, TransferDialog, DischargeDialog } from '@/components/admissions';
 import type { Gender, AdmissionStatus } from '@/types';
 
 function formatDate(dateString: string): string {
@@ -86,6 +89,9 @@ export default function PatientDetailPage({ params }: PatientDetailPageProps) {
   const [showMedForm, setShowMedForm] = useState(false);
   const [showNoteForm, setShowNoteForm] = useState(false);
   const [showIOForm, setShowIOForm] = useState(false);
+  const [showAdmissionForm, setShowAdmissionForm] = useState(false);
+  const [showTransferDialog, setShowTransferDialog] = useState(false);
+  const [showDischargeDialog, setShowDischargeDialog] = useState(false);
 
   if (isLoadingPatient) {
     return (
@@ -208,10 +214,36 @@ export default function PatientDetailPage({ params }: PatientDetailPageProps) {
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <Button className="w-full" variant="outline">
-              <FileText className="h-4 w-4 mr-2" />
-              New Admission
-            </Button>
+            {!currentAdmission && (
+              <Button
+                className="w-full"
+                variant="outline"
+                onClick={() => setShowAdmissionForm((prev) => !prev)}
+              >
+                <FileText className="h-4 w-4 mr-2" />
+                {showAdmissionForm ? 'Hide Admission Form' : 'New Admission'}
+              </Button>
+            )}
+            {currentAdmission && (
+              <>
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  onClick={() => setShowTransferDialog(true)}
+                >
+                  <ArrowRightLeft className="h-4 w-4 mr-2" />
+                  Transfer
+                </Button>
+                <Button
+                  className="w-full"
+                  variant="outline"
+                  onClick={() => setShowDischargeDialog(true)}
+                >
+                  <LogOut className="h-4 w-4 mr-2" />
+                  Discharge
+                </Button>
+              </>
+            )}
             {currentAdmission && (
               <>
                 <Button
@@ -271,6 +303,14 @@ export default function PatientDetailPage({ params }: PatientDetailPageProps) {
           </CardContent>
         </Card>
       </div>
+
+      {showAdmissionForm && !currentAdmission && (
+        <AdmissionForm
+          patientId={id}
+          onSuccess={() => setShowAdmissionForm(false)}
+          onCancel={() => setShowAdmissionForm(false)}
+        />
+      )}
 
       {currentAdmission && (
         <div className="space-y-6">
@@ -490,6 +530,24 @@ export default function PatientDetailPage({ params }: PatientDetailPageProps) {
           )}
         </CardContent>
       </Card>
+
+      {currentAdmission && (
+        <>
+          <TransferDialog
+            admissionId={currentAdmission.id}
+            currentBedId={currentAdmission.bedId}
+            open={showTransferDialog}
+            onOpenChange={setShowTransferDialog}
+            onSuccess={() => setShowTransferDialog(false)}
+          />
+          <DischargeDialog
+            admissionId={currentAdmission.id}
+            open={showDischargeDialog}
+            onOpenChange={setShowDischargeDialog}
+            onSuccess={() => setShowDischargeDialog(false)}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/admissions/admission-form.tsx
+++ b/apps/frontend/src/components/admissions/admission-form.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import { useState } from 'react';
+import { useCreateAdmission, useAvailableBeds, useFloors } from '@/hooks';
+import {
+  Button,
+  Input,
+  Label,
+  LegacySelect,
+  Textarea,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui';
+import type { AdmissionType } from '@/types';
+
+const admissionTypeOptions = [
+  { value: 'EMERGENCY', label: 'Emergency' },
+  { value: 'ELECTIVE', label: 'Elective' },
+  { value: 'TRANSFER', label: 'Transfer' },
+];
+
+interface AdmissionFormProps {
+  patientId: string;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export function AdmissionForm({ patientId, onSuccess, onCancel }: AdmissionFormProps) {
+  const createAdmission = useCreateAdmission();
+  const { data: floors } = useFloors();
+
+  const [floorId, setFloorId] = useState('');
+  const { data: availableBeds } = useAvailableBeds(floorId ? { floorId } : {});
+
+  const [form, setForm] = useState({
+    admissionType: 'ELECTIVE' as AdmissionType,
+    bedId: '',
+    admissionDate: new Date().toISOString().slice(0, 10),
+    admissionTime: new Date().toTimeString().slice(0, 5),
+    attendingDoctorId: '',
+    primaryNurseId: '',
+    diagnosis: '',
+    chiefComplaint: '',
+    expectedDischargeDate: '',
+    notes: '',
+  });
+
+  const floorOptions = [
+    { value: '', label: 'Select Floor' },
+    ...(floors?.map((f) => ({
+      value: f.id,
+      label: `${f.building ? f.building + ' - ' : ''}${f.name}`,
+    })) || []),
+  ];
+
+  const bedOptions = [
+    { value: '', label: 'Select Bed' },
+    ...(availableBeds?.map((b) => ({
+      value: b.id,
+      label: `${b.room.roomNumber} - ${b.bedNumber} (${b.room.roomType})`,
+    })) || []),
+  ];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createAdmission.mutateAsync({
+        patientId,
+        bedId: form.bedId,
+        admissionDate: form.admissionDate,
+        admissionTime: form.admissionTime,
+        admissionType: form.admissionType,
+        attendingDoctorId: form.attendingDoctorId,
+        primaryNurseId: form.primaryNurseId || undefined,
+        diagnosis: form.diagnosis || undefined,
+        chiefComplaint: form.chiefComplaint || undefined,
+        expectedDischargeDate: form.expectedDischargeDate || undefined,
+        notes: form.notes || undefined,
+      });
+      onSuccess();
+    } catch {
+      // Error handled by mutation
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>New Admission</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Admission Type *</Label>
+              <LegacySelect
+                options={admissionTypeOptions}
+                value={form.admissionType}
+                onChange={(e) =>
+                  setForm({ ...form, admissionType: e.target.value as AdmissionType })
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Floor</Label>
+              <LegacySelect
+                options={floorOptions}
+                value={floorId}
+                onChange={(e) => {
+                  setFloorId(e.target.value);
+                  setForm({ ...form, bedId: '' });
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Bed *</Label>
+              <LegacySelect
+                options={bedOptions}
+                value={form.bedId}
+                onChange={(e) => setForm({ ...form, bedId: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Admission Date *</Label>
+              <Input
+                type="date"
+                value={form.admissionDate}
+                onChange={(e) => setForm({ ...form, admissionDate: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Admission Time *</Label>
+              <Input
+                type="time"
+                value={form.admissionTime}
+                onChange={(e) => setForm({ ...form, admissionTime: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Attending Doctor ID *</Label>
+              <Input
+                value={form.attendingDoctorId}
+                onChange={(e) => setForm({ ...form, attendingDoctorId: e.target.value })}
+                placeholder="Doctor user ID"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Primary Nurse ID</Label>
+              <Input
+                value={form.primaryNurseId}
+                onChange={(e) => setForm({ ...form, primaryNurseId: e.target.value })}
+                placeholder="Nurse user ID (optional)"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Expected Discharge Date</Label>
+              <Input
+                type="date"
+                value={form.expectedDischargeDate}
+                onChange={(e) => setForm({ ...form, expectedDischargeDate: e.target.value })}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Diagnosis</Label>
+            <Input
+              value={form.diagnosis}
+              onChange={(e) => setForm({ ...form, diagnosis: e.target.value })}
+              placeholder="Primary diagnosis"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Chief Complaint</Label>
+            <Input
+              value={form.chiefComplaint}
+              onChange={(e) => setForm({ ...form, chiefComplaint: e.target.value })}
+              placeholder="Main symptom or complaint"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Notes</Label>
+            <Textarea
+              value={form.notes}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              placeholder="Additional notes..."
+              rows={3}
+            />
+          </div>
+
+          <div className="flex gap-2 justify-end">
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={
+                !form.bedId ||
+                !form.admissionDate ||
+                !form.admissionTime ||
+                !form.attendingDoctorId ||
+                createAdmission.isPending
+              }
+            >
+              {createAdmission.isPending ? 'Creating...' : 'Create Admission'}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/admissions/discharge-dialog.tsx
+++ b/apps/frontend/src/components/admissions/discharge-dialog.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import { useDischargePatient } from '@/hooks';
+import {
+  Button,
+  Input,
+  Label,
+  LegacySelect,
+  Textarea,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui';
+import type { DischargeType } from '@/types';
+
+const dischargeTypeOptions = [
+  { value: 'NORMAL', label: 'Normal Discharge' },
+  { value: 'TRANSFER', label: 'Transfer to Another Facility' },
+  { value: 'AMA', label: 'Against Medical Advice' },
+  { value: 'DECEASED', label: 'Deceased' },
+];
+
+interface DischargeDialogProps {
+  admissionId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function DischargeDialog({
+  admissionId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: DischargeDialogProps) {
+  const dischargePatient = useDischargePatient();
+
+  const [form, setForm] = useState({
+    dischargeType: 'NORMAL' as DischargeType,
+    dischargeDate: new Date().toISOString().slice(0, 10),
+    dischargeTime: new Date().toTimeString().slice(0, 5),
+    dischargeDiagnosis: '',
+    dischargeSummary: '',
+    followUpInstructions: '',
+    followUpDate: '',
+  });
+
+  const handleSubmit = async () => {
+    try {
+      await dischargePatient.mutateAsync({
+        admissionId,
+        data: {
+          dischargeDate: form.dischargeDate,
+          dischargeTime: form.dischargeTime,
+          dischargeType: form.dischargeType,
+          dischargeDiagnosis: form.dischargeDiagnosis || undefined,
+          dischargeSummary: form.dischargeSummary || undefined,
+          followUpInstructions: form.followUpInstructions || undefined,
+          followUpDate: form.followUpDate || undefined,
+        },
+      });
+      onSuccess();
+      onOpenChange(false);
+    } catch {
+      // Error handled by mutation
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Discharge Patient</DialogTitle>
+          <DialogDescription>
+            Complete the discharge form. The bed will be automatically released.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Discharge Type *</Label>
+            <LegacySelect
+              options={dischargeTypeOptions}
+              value={form.dischargeType}
+              onChange={(e) => setForm({ ...form, dischargeType: e.target.value as DischargeType })}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Discharge Date *</Label>
+              <Input
+                type="date"
+                value={form.dischargeDate}
+                onChange={(e) => setForm({ ...form, dischargeDate: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Discharge Time *</Label>
+              <Input
+                type="time"
+                value={form.dischargeTime}
+                onChange={(e) => setForm({ ...form, dischargeTime: e.target.value })}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Discharge Diagnosis</Label>
+            <Input
+              value={form.dischargeDiagnosis}
+              onChange={(e) => setForm({ ...form, dischargeDiagnosis: e.target.value })}
+              placeholder="Final diagnosis at discharge"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Discharge Summary</Label>
+            <Textarea
+              value={form.dischargeSummary}
+              onChange={(e) => setForm({ ...form, dischargeSummary: e.target.value })}
+              placeholder="Summary of hospitalization and treatment..."
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Follow-up Instructions</Label>
+            <Textarea
+              value={form.followUpInstructions}
+              onChange={(e) => setForm({ ...form, followUpInstructions: e.target.value })}
+              placeholder="Post-discharge care instructions..."
+              rows={2}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Follow-up Date</Label>
+            <Input
+              type="date"
+              value={form.followUpDate}
+              onChange={(e) => setForm({ ...form, followUpDate: e.target.value })}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleSubmit}
+            disabled={dischargePatient.isPending}
+          >
+            {dischargePatient.isPending ? 'Discharging...' : 'Confirm Discharge'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/components/admissions/index.ts
+++ b/apps/frontend/src/components/admissions/index.ts
@@ -1,0 +1,3 @@
+export { AdmissionForm } from './admission-form';
+export { TransferDialog } from './transfer-dialog';
+export { DischargeDialog } from './discharge-dialog';

--- a/apps/frontend/src/components/admissions/transfer-dialog.tsx
+++ b/apps/frontend/src/components/admissions/transfer-dialog.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import { useTransferPatient, useAvailableBeds, useFloors } from '@/hooks';
+import {
+  Button,
+  Input,
+  Label,
+  LegacySelect,
+  Textarea,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui';
+
+interface TransferDialogProps {
+  admissionId: string;
+  currentBedId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function TransferDialog({
+  admissionId,
+  open,
+  onOpenChange,
+  onSuccess,
+}: TransferDialogProps) {
+  const transferPatient = useTransferPatient();
+  const { data: floors } = useFloors();
+
+  const [floorId, setFloorId] = useState('');
+  const { data: availableBeds } = useAvailableBeds(floorId ? { floorId } : {});
+
+  const [form, setForm] = useState({
+    toBedId: '',
+    transferDate: new Date().toISOString().slice(0, 10),
+    transferTime: new Date().toTimeString().slice(0, 5),
+    reason: '',
+    notes: '',
+  });
+
+  const floorOptions = [
+    { value: '', label: 'Select Floor' },
+    ...(floors?.map((f) => ({
+      value: f.id,
+      label: `${f.building ? f.building + ' - ' : ''}${f.name}`,
+    })) || []),
+  ];
+
+  const bedOptions = [
+    { value: '', label: 'Select Destination Bed' },
+    ...(availableBeds?.map((b) => ({
+      value: b.id,
+      label: `${b.room.roomNumber} - ${b.bedNumber} (${b.room.roomType})`,
+    })) || []),
+  ];
+
+  const handleSubmit = async () => {
+    try {
+      await transferPatient.mutateAsync({
+        admissionId,
+        data: {
+          toBedId: form.toBedId,
+          transferDate: form.transferDate,
+          transferTime: form.transferTime,
+          reason: form.reason,
+          notes: form.notes || undefined,
+        },
+      });
+      onSuccess();
+      onOpenChange(false);
+    } catch {
+      // Error handled by mutation
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Transfer Patient</DialogTitle>
+          <DialogDescription>
+            Select a new bed and provide a reason for the transfer.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>Floor</Label>
+            <LegacySelect
+              options={floorOptions}
+              value={floorId}
+              onChange={(e) => {
+                setFloorId(e.target.value);
+                setForm({ ...form, toBedId: '' });
+              }}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Destination Bed *</Label>
+            <LegacySelect
+              options={bedOptions}
+              value={form.toBedId}
+              onChange={(e) => setForm({ ...form, toBedId: e.target.value })}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Transfer Date *</Label>
+              <Input
+                type="date"
+                value={form.transferDate}
+                onChange={(e) => setForm({ ...form, transferDate: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Transfer Time *</Label>
+              <Input
+                type="time"
+                value={form.transferTime}
+                onChange={(e) => setForm({ ...form, transferTime: e.target.value })}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label>Reason *</Label>
+            <Input
+              value={form.reason}
+              onChange={(e) => setForm({ ...form, reason: e.target.value })}
+              placeholder="Reason for transfer"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Notes</Label>
+            <Textarea
+              value={form.notes}
+              onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              placeholder="Additional notes..."
+              rows={2}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!form.toBedId || !form.reason || transferPatient.isPending}
+          >
+            {transferPatient.isPending ? 'Transferring...' : 'Transfer'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -1,6 +1,12 @@
 export { useFormWithZod } from './use-form-with-zod';
-export { usePatients, usePatient, usePatientSearch } from './use-patients';
-export { usePatientAdmissions, useAdmission } from './use-admissions';
+export { usePatients, usePatient, usePatientSearch, useCreatePatient } from './use-patients';
+export {
+  usePatientAdmissions,
+  useAdmission,
+  useCreateAdmission,
+  useTransferPatient,
+  useDischargePatient,
+} from './use-admissions';
 export { useDebounce } from './use-debounce';
 export { useFloors, useFloorDashboard, useAvailableBeds } from './use-rooms';
 export { useRoomWebSocket } from './use-room-websocket';

--- a/apps/frontend/src/hooks/use-admissions.ts
+++ b/apps/frontend/src/hooks/use-admissions.ts
@@ -1,5 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { admissionApi } from '@/services';
+import type { CreateAdmissionData, TransferData, DischargeData } from '@/types';
 
 export function usePatientAdmissions(patientId: string) {
   return useQuery({
@@ -14,5 +15,47 @@ export function useAdmission(id: string) {
     queryKey: ['admission', id],
     queryFn: () => admissionApi.findById(id),
     enabled: !!id,
+  });
+}
+
+export function useCreateAdmission() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateAdmissionData) => admissionApi.create(data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['admissions'] });
+      queryClient.invalidateQueries({ queryKey: ['admissions', 'patient', variables.patientId] });
+      queryClient.invalidateQueries({ queryKey: ['available-beds'] });
+      queryClient.invalidateQueries({ queryKey: ['floor-dashboard'] });
+    },
+  });
+}
+
+export function useTransferPatient() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ admissionId, data }: { admissionId: string; data: TransferData }) =>
+      admissionApi.transfer(admissionId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admissions'] });
+      queryClient.invalidateQueries({ queryKey: ['available-beds'] });
+      queryClient.invalidateQueries({ queryKey: ['floor-dashboard'] });
+    },
+  });
+}
+
+export function useDischargePatient() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ admissionId, data }: { admissionId: string; data: DischargeData }) =>
+      admissionApi.discharge(admissionId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admissions'] });
+      queryClient.invalidateQueries({ queryKey: ['available-beds'] });
+      queryClient.invalidateQueries({ queryKey: ['floor-dashboard'] });
+    },
   });
 }

--- a/apps/frontend/src/hooks/use-patients.ts
+++ b/apps/frontend/src/hooks/use-patients.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { patientApi } from '@/services';
-import type { FindPatientsParams } from '@/types';
+import type { FindPatientsParams, CreatePatientData } from '@/types';
 
 export function usePatients(params: FindPatientsParams = {}) {
   return useQuery({
@@ -22,5 +22,16 @@ export function usePatientSearch(query: string) {
     queryKey: ['patient-search', query],
     queryFn: () => patientApi.search(query),
     enabled: query.length >= 2,
+  });
+}
+
+export function useCreatePatient() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreatePatientData) => patientApi.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['patients'] });
+    },
   });
 }

--- a/apps/frontend/src/services/admission-api.ts
+++ b/apps/frontend/src/services/admission-api.ts
@@ -1,5 +1,13 @@
-import { apiGet } from '@/lib/api-client';
-import type { Admission, PaginatedAdmissions } from '@/types';
+import { apiGet, apiPost } from '@/lib/api-client';
+import type {
+  Admission,
+  PaginatedAdmissions,
+  CreateAdmissionData,
+  TransferData,
+  Transfer,
+  DischargeData,
+  Discharge,
+} from '@/types';
 
 interface FindAdmissionsParams {
   patientId?: string;
@@ -34,5 +42,25 @@ export const admissionApi = {
       `/admissions?patientId=${patientId}&limit=100`,
     );
     return response.data;
+  },
+
+  findActiveByPatientId: (patientId: string): Promise<Admission | null> => {
+    return apiGet<Admission | null>(`/admissions/patient/${patientId}/active`);
+  },
+
+  create: (data: CreateAdmissionData): Promise<Admission> => {
+    return apiPost<Admission>('/admissions', data);
+  },
+
+  transfer: (admissionId: string, data: TransferData): Promise<Transfer> => {
+    return apiPost<Transfer>(`/admissions/${admissionId}/transfer`, data);
+  },
+
+  discharge: (admissionId: string, data: DischargeData): Promise<Discharge> => {
+    return apiPost<Discharge>(`/admissions/${admissionId}/discharge`, data);
+  },
+
+  getTransfers: (admissionId: string): Promise<Transfer[]> => {
+    return apiGet<Transfer[]>(`/admissions/${admissionId}/transfers`);
   },
 };

--- a/apps/frontend/src/services/patient-api.ts
+++ b/apps/frontend/src/services/patient-api.ts
@@ -1,5 +1,5 @@
-import { apiGet } from '@/lib/api-client';
-import type { Patient, PaginatedPatients, FindPatientsParams } from '@/types';
+import { apiGet, apiPost, apiPatch } from '@/lib/api-client';
+import type { Patient, PaginatedPatients, FindPatientsParams, CreatePatientData } from '@/types';
 
 function buildQueryString(params: FindPatientsParams): string {
   const searchParams = new URLSearchParams();
@@ -32,5 +32,13 @@ export const patientApi = {
 
   search: (query: string): Promise<Patient[]> => {
     return apiGet<Patient[]>(`/patients/search?q=${encodeURIComponent(query)}`);
+  },
+
+  create: (data: CreatePatientData): Promise<Patient> => {
+    return apiPost<Patient>('/patients', data);
+  },
+
+  update: (id: string, data: Partial<CreatePatientData>): Promise<Patient> => {
+    return apiPatch<Patient>(`/patients/${id}`, data);
   },
 };

--- a/apps/frontend/src/types/admission.ts
+++ b/apps/frontend/src/types/admission.ts
@@ -1,6 +1,6 @@
-export type AdmissionType = 'EMERGENCY' | 'SCHEDULED' | 'TRANSFER';
+export type AdmissionType = 'EMERGENCY' | 'ELECTIVE' | 'TRANSFER';
 export type AdmissionStatus = 'ACTIVE' | 'TRANSFERRED' | 'DISCHARGED';
-export type DischargeType = 'NORMAL' | 'TRANSFER' | 'ESCAPE' | 'DEATH';
+export type DischargeType = 'NORMAL' | 'TRANSFER' | 'AMA' | 'DECEASED';
 
 export interface Transfer {
   id: string;
@@ -57,4 +57,48 @@ export interface PaginatedAdmissions {
   page: number;
   limit: number;
   totalPages: number;
+}
+
+export interface CreateAdmissionData {
+  patientId: string;
+  bedId: string;
+  admissionDate: string;
+  admissionTime: string;
+  admissionType: AdmissionType;
+  diagnosis?: string;
+  chiefComplaint?: string;
+  attendingDoctorId: string;
+  primaryNurseId?: string;
+  expectedDischargeDate?: string;
+  notes?: string;
+}
+
+export interface TransferData {
+  toBedId: string;
+  transferDate: string;
+  transferTime: string;
+  reason: string;
+  notes?: string;
+}
+
+export interface DischargeData {
+  dischargeDate: string;
+  dischargeTime: string;
+  dischargeType: DischargeType;
+  dischargeDiagnosis?: string;
+  dischargeSummary?: string;
+  followUpInstructions?: string;
+  followUpDate?: string;
+}
+
+export interface CreatePatientData {
+  name: string;
+  birthDate: string;
+  gender: 'MALE' | 'FEMALE';
+  bloodType?: string;
+  phone?: string;
+  address?: string;
+  emergencyContactName?: string;
+  emergencyContactPhone?: string;
+  emergencyContactRelation?: string;
 }


### PR DESCRIPTION
## Summary
- Fix AdmissionType and DischargeType enum mismatches between frontend and backend
- Add write operations (create, transfer, discharge) to admission API service
- Add create/update operations to patient API service
- Create AdmissionForm component with floor/bed selection from available beds
- Create TransferDialog with destination bed selection and reason input
- Create DischargeDialog with discharge type, summary, and follow-up fields
- Wire all workflow buttons into patient detail page

## Test plan
- [ ] Verify admission creation with bed selection works
- [ ] Verify transfer dialog shows available beds and submits correctly
- [ ] Verify discharge dialog completes and updates admission status
- [ ] Verify bed availability updates after admission/transfer/discharge

Closes #194