### PR TITLE
feat(auth): implement secure token storage and refresh flow

### DIFF
--- a/apps/frontend/src/components/auth/auth-guard.tsx
+++ b/apps/frontend/src/components/auth/auth-guard.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/stores';
+import { ChangePasswordModal } from './change-password-modal';
 
 const PUBLIC_PATHS = ['/login'];
 
@@ -13,10 +14,12 @@ interface AuthGuardProps {
 export function AuthGuard({ children }: AuthGuardProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const { isAuthenticated } = useAuthStore();
-  const [isChecking, setIsChecking] = useState(true);
+  const { isAuthenticated, isHydrated, user } = useAuthStore();
+  const [showChangePassword, setShowChangePassword] = useState(false);
 
   useEffect(() => {
+    if (!isHydrated) return;
+
     const isPublicPath = PUBLIC_PATHS.includes(pathname);
 
     if (!isAuthenticated && !isPublicPath) {
@@ -24,11 +27,15 @@ export function AuthGuard({ children }: AuthGuardProps) {
     } else if (isAuthenticated && isPublicPath) {
       router.replace('/');
     }
+  }, [isAuthenticated, isHydrated, pathname, router]);
 
-    setIsChecking(false);
-  }, [isAuthenticated, pathname, router]);
+  useEffect(() => {
+    if (isHydrated && isAuthenticated && user?.mustChangePassword) {
+      setShowChangePassword(true);
+    }
+  }, [isHydrated, isAuthenticated, user?.mustChangePassword]);
 
-  if (isChecking) {
+  if (!isHydrated) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
@@ -36,5 +43,32 @@ export function AuthGuard({ children }: AuthGuardProps) {
     );
   }
 
-  return <>{children}</>;
+  const isPublicPath = PUBLIC_PATHS.includes(pathname);
+  if (!isAuthenticated && !isPublicPath) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {children}
+      {showChangePassword && (
+        <ChangePasswordModal
+          isOpen={showChangePassword}
+          onClose={() => {
+            // Only allow closing if password was changed
+          }}
+          onSuccess={() => {
+            useAuthStore.setState({
+              user: user ? { ...user, mustChangePassword: false } : null,
+            });
+            setShowChangePassword(false);
+          }}
+        />
+      )}
+    </>
+  );
 }

--- a/apps/frontend/src/lib/api-client.ts
+++ b/apps/frontend/src/lib/api-client.ts
@@ -70,7 +70,7 @@ async function handleTokenRefresh(): Promise<string | null> {
   isRefreshing = true;
 
   try {
-    await useAuthStore.getState().refreshToken();
+    await useAuthStore.getState().refresh();
     const newToken = useAuthStore.getState().accessToken;
     if (newToken) {
       onTokenRefreshed(newToken);

--- a/apps/frontend/src/services/auth-api.ts
+++ b/apps/frontend/src/services/auth-api.ts
@@ -21,8 +21,11 @@ export async function logout(): Promise<void> {
   return apiPost<void>(AUTH_ENDPOINTS.LOGOUT);
 }
 
-export async function refreshToken(): Promise<RefreshTokenResponse> {
-  return apiPost<RefreshTokenResponse>(AUTH_ENDPOINTS.REFRESH);
+export async function refreshToken(token?: string): Promise<RefreshTokenResponse> {
+  return apiPost<RefreshTokenResponse>(
+    AUTH_ENDPOINTS.REFRESH,
+    token ? { refreshToken: token } : undefined,
+  );
 }
 
 export async function changePassword(data: ChangePasswordRequest): Promise<void> {

--- a/apps/frontend/src/stores/auth-store.ts
+++ b/apps/frontend/src/stores/auth-store.ts
@@ -6,13 +6,15 @@ import { authApi } from '@/services';
 interface AuthState {
   user: User | null;
   accessToken: string | null;
+  refreshToken: string | null;
   isAuthenticated: boolean;
+  isHydrated: boolean;
   isLoading: boolean;
   error: string | null;
 
   login: (credentials: LoginCredentials) => Promise<void>;
   logout: () => Promise<void>;
-  refreshToken: () => Promise<void>;
+  refresh: () => Promise<void>;
   setUser: (user: User) => void;
   setAuth: (user: User, accessToken: string) => void;
   clearAuth: () => void;
@@ -24,7 +26,9 @@ export const useAuthStore = create<AuthState>()(
     (set, get) => ({
       user: null,
       accessToken: null,
+      refreshToken: null,
       isAuthenticated: false,
+      isHydrated: false,
       isLoading: false,
       error: null,
 
@@ -35,6 +39,7 @@ export const useAuthStore = create<AuthState>()(
           set({
             user: response.user,
             accessToken: response.accessToken,
+            refreshToken: response.refreshToken || null,
             isAuthenticated: true,
             isLoading: false,
             error: null,
@@ -55,15 +60,17 @@ export const useAuthStore = create<AuthState>()(
           set({
             user: null,
             accessToken: null,
+            refreshToken: null,
             isAuthenticated: false,
             error: null,
           });
         }
       },
 
-      refreshToken: async () => {
+      refresh: async () => {
+        const { refreshToken } = get();
         try {
-          const response = await authApi.refreshToken();
+          const response = await authApi.refreshToken(refreshToken || undefined);
           set({ accessToken: response.accessToken });
         } catch (error) {
           get().clearAuth();
@@ -80,6 +87,7 @@ export const useAuthStore = create<AuthState>()(
         set({
           user: null,
           accessToken: null,
+          refreshToken: null,
           isAuthenticated: false,
           error: null,
         }),
@@ -91,8 +99,16 @@ export const useAuthStore = create<AuthState>()(
       partialize: (state) => ({
         user: state.user,
         accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
         isAuthenticated: state.isAuthenticated,
       }),
+      onRehydrateStorage: () => {
+        return (_state, error) => {
+          if (!error) {
+            useAuthStore.setState({ isHydrated: true });
+          }
+        };
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
- Store refresh token from login response and send it in refresh API calls
- Fix AuthGuard hydration race condition using Zustand's `onRehydrateStorage` callback
- Enforce `mustChangePassword` flag by showing ChangePasswordModal before allowing dashboard access
- Update api-client to use renamed `refresh` method that passes stored refresh token

## Changes
- `auth-store.ts` — Add `refreshToken` and `isHydrated` state, `onRehydrateStorage` handler
- `auth-api.ts` — Accept optional refresh token parameter in `refreshToken()` call
- `api-client.ts` — Update `handleTokenRefresh` to call `refresh()` method
- `auth-guard.tsx` — Wait for hydration before routing decisions, show ChangePasswordModal when required

## Test plan
- [ ] Verify no flash redirect to /login on page reload
- [ ] Verify token refresh sends refresh token in request body
- [ ] Verify mustChangePassword users see password modal
- [ ] Verify password change success dismisses modal

Closes #196