### PR TITLE
fix(ci): enforce security scan and build pipeline gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,9 +58,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
           format: 'sarif'
           output: 'trivy-results.sarif'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,13 @@ jobs:
         uses: codecov/codecov-action@v4
         if: github.event_name == 'pull_request'
         with:
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
-        continue-on-error: true
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: [lint, typecheck, test]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Run pnpm audit
         run: pnpm audit --audit-level=high
-        continue-on-error: true
 
   codeql-analysis:
     name: CodeQL Analysis
@@ -77,7 +76,6 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
 
   dependency-review:
     name: Dependency Review


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from dependency audit and secret scanning steps in security pipeline
- Add job dependencies in CI pipeline: build now requires lint + typecheck + test to pass first
- Set `fail_ci_if_error: true` for coverage upload to catch coverage failures
- Pin Trivy action to specific version (v0.28.0) and configure severity filter with exit code

## Test plan
- [ ] Verify security pipeline blocks on high-severity audit findings
- [ ] Verify gitleaks blocks on detected secrets
- [ ] Verify build job only runs after lint, typecheck, and test succeed
- [ ] Verify Trivy scan fails on critical/high vulnerabilities

Closes #197