### PR TITLE
feat(report): add daily report page and dashboard home

### DIFF
--- a/apps/frontend/src/app/(dashboard)/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/page.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import Link from 'next/link';
+import { usePatients } from '@/hooks';
+import { useFloors } from '@/hooks';
+import { useRounds } from '@/hooks';
+import { Card, CardContent, CardHeader, CardTitle, Skeleton } from '@/components/ui';
+import { Users, BedDouble, ClipboardList, FileBarChart, Activity, ArrowRight } from 'lucide-react';
+
+function formatToday(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export default function DashboardHomePage() {
+  const today = formatToday();
+
+  const { data: patients, isLoading: patientsLoading } = usePatients();
+  const { data: floors, isLoading: floorsLoading } = useFloors();
+  const { data: todayRounds, isLoading: roundsLoading } = useRounds({
+    scheduledDateFrom: today,
+    scheduledDateTo: today,
+  });
+
+  const totalPatients = patients?.total ?? 0;
+  const totalFloors = floors?.length ?? 0;
+  const activeRounds =
+    todayRounds?.data?.filter((r) => r.status === 'SCHEDULED' || r.status === 'IN_PROGRESS')
+      .length ?? 0;
+  const completedRounds = todayRounds?.data?.filter((r) => r.status === 'COMPLETED').length ?? 0;
+
+  const summaryCards = [
+    {
+      title: 'Total Patients',
+      value: totalPatients,
+      icon: Users,
+      href: '/patients',
+      loading: patientsLoading,
+      color: 'text-blue-600',
+      bg: 'bg-blue-50',
+    },
+    {
+      title: 'Floors',
+      value: totalFloors,
+      icon: BedDouble,
+      href: '/rooms',
+      loading: floorsLoading,
+      color: 'text-green-600',
+      bg: 'bg-green-50',
+    },
+    {
+      title: 'Active Rounds',
+      value: activeRounds,
+      icon: ClipboardList,
+      href: '/rounding',
+      loading: roundsLoading,
+      color: 'text-orange-600',
+      bg: 'bg-orange-50',
+    },
+    {
+      title: 'Completed Today',
+      value: completedRounds,
+      icon: Activity,
+      href: '/rounding',
+      loading: roundsLoading,
+      color: 'text-purple-600',
+      bg: 'bg-purple-50',
+    },
+  ];
+
+  const quickLinks = [
+    { label: 'Patient List', href: '/patients', icon: Users },
+    { label: 'Room Dashboard', href: '/rooms', icon: BedDouble },
+    { label: 'Rounding', href: '/rounding', icon: ClipboardList },
+    { label: 'Daily Reports', href: '/reports/daily-reports', icon: FileBarChart },
+  ];
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Dashboard</h1>
+        <p className="text-muted-foreground mt-1">Hospital inpatient management overview</p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {summaryCards.map((card) => (
+          <Link key={card.title} href={card.href}>
+            <Card className="hover:shadow-md transition-shadow cursor-pointer">
+              <CardContent className="p-6">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground">{card.title}</p>
+                    {card.loading ? (
+                      <Skeleton className="h-8 w-16 mt-1" />
+                    ) : (
+                      <p className="text-3xl font-bold mt-1">{card.value}</p>
+                    )}
+                  </div>
+                  <div className={`p-3 rounded-lg ${card.bg}`}>
+                    <card.icon className={`h-6 w-6 ${card.color}`} />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Quick Access</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {quickLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="flex items-center justify-between p-3 rounded-lg hover:bg-accent transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <link.icon className="h-5 w-5 text-muted-foreground" />
+                    <span className="font-medium">{link.label}</span>
+                  </div>
+                  <ArrowRight className="h-4 w-4 text-muted-foreground" />
+                </Link>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Today&apos;s Rounds</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {roundsLoading ? (
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={i} className="h-12 w-full" />
+                ))}
+              </div>
+            ) : todayRounds?.data && todayRounds.data.length > 0 ? (
+              <div className="space-y-2">
+                {todayRounds.data.slice(0, 5).map((round) => (
+                  <Link
+                    key={round.id}
+                    href={`/rounding/${round.id}`}
+                    className="flex items-center justify-between p-3 rounded-lg hover:bg-accent transition-colors"
+                  >
+                    <div>
+                      <p className="font-medium">{round.roundNumber}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {round.roundType} &middot; {round.scheduledDate}
+                      </p>
+                    </div>
+                    <span
+                      className={`text-xs font-medium px-2 py-1 rounded-full ${
+                        round.status === 'COMPLETED'
+                          ? 'bg-green-100 text-green-700'
+                          : round.status === 'IN_PROGRESS'
+                            ? 'bg-blue-100 text-blue-700'
+                            : round.status === 'SCHEDULED'
+                              ? 'bg-yellow-100 text-yellow-700'
+                              : 'bg-gray-100 text-gray-700'
+                      }`}
+                    >
+                      {round.status}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <p className="text-muted-foreground text-center py-8">
+                No rounds scheduled for today
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/(dashboard)/reports/daily-reports/page.tsx
+++ b/apps/frontend/src/app/(dashboard)/reports/daily-reports/page.tsx
@@ -1,0 +1,606 @@
+'use client';
+
+import { useState } from 'react';
+import { usePatients } from '@/hooks';
+import { useDailyReportList, useDailySummary, useGenerateDailyReport } from '@/hooks';
+import { usePatientAdmissions } from '@/hooks';
+import type { DailyReport, DailySummary, AlertSeverity } from '@/types';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Button,
+  Input,
+  LegacySelect,
+  Skeleton,
+  Badge,
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from '@/components/ui';
+import {
+  FileBarChart,
+  RefreshCw,
+  Activity,
+  Droplets,
+  Pill,
+  AlertTriangle,
+  ChevronLeft,
+} from 'lucide-react';
+
+function formatToday(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function severityColor(severity: AlertSeverity): string {
+  switch (severity) {
+    case 'CRITICAL':
+      return 'destructive';
+    case 'HIGH':
+      return 'destructive';
+    case 'MEDIUM':
+      return 'warning';
+    case 'LOW':
+      return 'secondary';
+    default:
+      return 'secondary';
+  }
+}
+
+export default function DailyReportsPage() {
+  const [selectedPatientId, setSelectedPatientId] = useState('');
+  const [selectedAdmissionId, setSelectedAdmissionId] = useState('');
+  const [selectedDate, setSelectedDate] = useState(formatToday());
+  const [viewMode, setViewMode] = useState<'list' | 'detail'>('list');
+  const [selectedReport, setSelectedReport] = useState<DailyReport | null>(null);
+
+  const { data: patients, isLoading: patientsLoading } = usePatients();
+  const { data: admissions } = usePatientAdmissions(selectedPatientId);
+  const { data: reportList, isLoading: listLoading } = useDailyReportList(selectedAdmissionId, {
+    limit: 20,
+  });
+  const { data: liveSummary, isLoading: summaryLoading } = useDailySummary(
+    selectedAdmissionId,
+    selectedDate,
+  );
+  const generateReport = useGenerateDailyReport(selectedAdmissionId);
+
+  const patientOptions = [
+    { value: '', label: 'Select Patient' },
+    ...(patients?.data?.map((p) => ({
+      value: p.id,
+      label: `${p.name} (${p.patientNumber})`,
+    })) ?? []),
+  ];
+
+  const admissionOptions = [
+    { value: '', label: 'Select Admission' },
+    ...(admissions?.map((a) => ({
+      value: a.id,
+      label: `${a.admissionDate} - ${a.status}`,
+    })) ?? []),
+  ];
+
+  const handlePatientChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedPatientId(e.target.value);
+    setSelectedAdmissionId('');
+    setSelectedReport(null);
+    setViewMode('list');
+  };
+
+  const handleAdmissionChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSelectedAdmissionId(e.target.value);
+    setSelectedReport(null);
+    setViewMode('list');
+  };
+
+  const handleGenerate = () => {
+    if (!selectedAdmissionId || !selectedDate) return;
+    generateReport.mutate(selectedDate);
+  };
+
+  const handleViewReport = (report: DailyReport) => {
+    setSelectedReport(report);
+    setViewMode('detail');
+  };
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          {viewMode === 'detail' && (
+            <Button variant="ghost" size="sm" onClick={() => setViewMode('list')}>
+              <ChevronLeft className="h-4 w-4 mr-1" />
+              Back
+            </Button>
+          )}
+          <div>
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <FileBarChart className="h-6 w-6" />
+              Daily Reports
+            </h1>
+            <p className="text-muted-foreground mt-1">View and generate daily patient reports</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <Card>
+        <CardContent className="p-4">
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex-1">
+              {patientsLoading ? (
+                <Skeleton className="h-9 w-full" />
+              ) : (
+                <LegacySelect
+                  options={patientOptions}
+                  value={selectedPatientId}
+                  onChange={handlePatientChange}
+                />
+              )}
+            </div>
+            <div className="flex-1">
+              <LegacySelect
+                options={admissionOptions}
+                value={selectedAdmissionId}
+                onChange={handleAdmissionChange}
+              />
+            </div>
+            <div className="w-full md:w-48">
+              <Input
+                type="date"
+                value={selectedDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+              />
+            </div>
+            <Button
+              onClick={handleGenerate}
+              disabled={!selectedAdmissionId || !selectedDate || generateReport.isPending}
+            >
+              <RefreshCw
+                className={`h-4 w-4 mr-2 ${generateReport.isPending ? 'animate-spin' : ''}`}
+              />
+              Generate
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Content Area */}
+      {!selectedAdmissionId ? (
+        <Card>
+          <CardContent className="p-12 text-center">
+            <FileBarChart className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <p className="text-muted-foreground">
+              Select a patient and admission to view daily reports.
+            </p>
+          </CardContent>
+        </Card>
+      ) : viewMode === 'detail' && selectedReport ? (
+        <ReportDetailView report={selectedReport} />
+      ) : (
+        <div className="space-y-6">
+          {/* Live Summary */}
+          {selectedDate && (
+            <LiveSummaryCard summary={liveSummary} loading={summaryLoading} date={selectedDate} />
+          )}
+
+          {/* Report List */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-lg">Report History</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {listLoading ? (
+                <div className="space-y-3">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-12 w-full" />
+                  ))}
+                </div>
+              ) : reportList?.data && reportList.data.length > 0 ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Date</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Vitals</TableHead>
+                      <TableHead>I/O Balance</TableHead>
+                      <TableHead>Medications</TableHead>
+                      <TableHead>Alerts</TableHead>
+                      <TableHead>Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {reportList.data.map((report) => (
+                      <TableRow key={report.id}>
+                        <TableCell className="font-medium">{report.reportDate}</TableCell>
+                        <TableCell>
+                          {report.patientStatus && (
+                            <Badge
+                              variant={
+                                report.patientStatus === 'CRITICAL'
+                                  ? 'destructive'
+                                  : report.patientStatus === 'DECLINING'
+                                    ? 'destructive'
+                                    : report.patientStatus === 'STABLE'
+                                      ? 'secondary'
+                                      : 'outline'
+                              }
+                            >
+                              {report.patientStatus}
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {report.vitalsSummary
+                            ? `${report.vitalsSummary.measurementCount} measurements`
+                            : '-'}
+                        </TableCell>
+                        <TableCell>
+                          {report.ioBalance != null
+                            ? `${report.ioBalance > 0 ? '+' : ''}${report.ioBalance} mL`
+                            : '-'}
+                        </TableCell>
+                        <TableCell>
+                          {report.medicationsGiven != null
+                            ? `${report.medicationsGiven} given`
+                            : '-'}
+                          {report.medicationsHeld != null && report.medicationsHeld > 0 && (
+                            <span className="text-yellow-600 ml-1">
+                              ({report.medicationsHeld} held)
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          {report.alerts?.length ? (
+                            <Badge variant="destructive">{report.alerts.length}</Badge>
+                          ) : (
+                            <span className="text-muted-foreground">None</span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleViewReport(report)}
+                          >
+                            View
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <p className="text-muted-foreground text-center py-8">
+                  No reports generated yet for this admission.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LiveSummaryCard({
+  summary,
+  loading,
+  date,
+}: {
+  summary: DailySummary | undefined;
+  loading: boolean;
+  date: string;
+}) {
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-32" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!summary) return null;
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-muted-foreground">Live Summary for {date}</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {/* Vitals Card */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Activity className="h-4 w-4 text-blue-600" />
+              <span className="text-sm font-medium">Vitals</span>
+            </div>
+            {summary.vitalsSummary ? (
+              <div className="space-y-1 text-sm">
+                <p>{summary.vitalsSummary.measurementCount} measurements</p>
+                {summary.vitalsSummary.temperature && (
+                  <p className="text-muted-foreground">
+                    Temp: {summary.vitalsSummary.temperature.avg.toFixed(1)}&deg;C
+                  </p>
+                )}
+                {summary.vitalsSummary.pulseRate && (
+                  <p className="text-muted-foreground">
+                    Pulse: {summary.vitalsSummary.pulseRate.avg.toFixed(0)} bpm
+                  </p>
+                )}
+                {summary.vitalsSummary.alertCount > 0 && (
+                  <p className="text-red-600 font-medium">
+                    {summary.vitalsSummary.alertCount} alert(s)
+                  </p>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No data</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* I/O Balance Card */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Droplets className="h-4 w-4 text-cyan-600" />
+              <span className="text-sm font-medium">I/O Balance</span>
+            </div>
+            {summary.ioBalance ? (
+              <div className="space-y-1 text-sm">
+                <p className="text-lg font-bold">
+                  {summary.ioBalance.balance > 0 ? '+' : ''}
+                  {summary.ioBalance.balance} mL
+                </p>
+                <p className="text-muted-foreground">In: {summary.ioBalance.intake.total} mL</p>
+                <p className="text-muted-foreground">Out: {summary.ioBalance.output.total} mL</p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">No data</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Medications Card */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Pill className="h-4 w-4 text-green-600" />
+              <span className="text-sm font-medium">Medications</span>
+            </div>
+            <div className="space-y-1 text-sm">
+              <p className="text-lg font-bold">
+                {summary.medicationCompliance.complianceRate.toFixed(0)}%
+              </p>
+              <p className="text-muted-foreground">
+                {summary.medicationCompliance.administered}/{summary.medicationCompliance.scheduled}{' '}
+                administered
+              </p>
+              {summary.medicationCompliance.held > 0 && (
+                <p className="text-yellow-600">{summary.medicationCompliance.held} held</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Alerts Card */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <AlertTriangle className="h-4 w-4 text-red-600" />
+              <span className="text-sm font-medium">Alerts</span>
+            </div>
+            {summary.alerts.length > 0 ? (
+              <div className="space-y-1">
+                {summary.alerts.slice(0, 3).map((alert, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <Badge
+                      variant={
+                        severityColor(alert.severity) as 'destructive' | 'secondary' | 'outline'
+                      }
+                    >
+                      {alert.severity}
+                    </Badge>
+                    <span className="text-xs truncate">{alert.message}</span>
+                  </div>
+                ))}
+                {summary.alerts.length > 3 && (
+                  <p className="text-xs text-muted-foreground">+{summary.alerts.length - 3} more</p>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-green-600 font-medium">No alerts</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function ReportDetailView({ report }: { report: DailyReport }) {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle>Report: {report.reportDate}</CardTitle>
+            {report.patientStatus && (
+              <Badge
+                variant={
+                  report.patientStatus === 'CRITICAL'
+                    ? 'destructive'
+                    : report.patientStatus === 'DECLINING'
+                      ? 'destructive'
+                      : 'secondary'
+                }
+              >
+                {report.patientStatus}
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Generated at {new Date(report.generatedAt).toLocaleString()}
+          </p>
+        </CardHeader>
+        <CardContent>
+          {report.summary && (
+            <div className="mb-6">
+              <h4 className="font-medium mb-2">Summary</h4>
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap">{report.summary}</p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <div className="p-4 rounded-lg bg-accent/50">
+              <p className="text-sm text-muted-foreground">I/O Balance</p>
+              <p className="text-2xl font-bold">
+                {report.ioBalance != null
+                  ? `${report.ioBalance > 0 ? '+' : ''}${report.ioBalance} mL`
+                  : 'N/A'}
+              </p>
+              <div className="text-xs text-muted-foreground mt-1">
+                <span>Intake: {report.totalIntake ?? 0} mL</span>
+                {' / '}
+                <span>Output: {report.totalOutput ?? 0} mL</span>
+              </div>
+            </div>
+
+            <div className="p-4 rounded-lg bg-accent/50">
+              <p className="text-sm text-muted-foreground">Medications Given</p>
+              <p className="text-2xl font-bold">{report.medicationsGiven ?? 0}</p>
+              {report.medicationsHeld != null && report.medicationsHeld > 0 && (
+                <p className="text-xs text-yellow-600 mt-1">{report.medicationsHeld} held</p>
+              )}
+            </div>
+
+            <div className="p-4 rounded-lg bg-accent/50">
+              <p className="text-sm text-muted-foreground">Vital Measurements</p>
+              <p className="text-2xl font-bold">{report.vitalsSummary?.measurementCount ?? 0}</p>
+              {report.vitalsSummary && report.vitalsSummary.alertCount > 0 && (
+                <p className="text-xs text-red-600 mt-1">
+                  {report.vitalsSummary.alertCount} alert(s)
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Vitals Detail */}
+          {report.vitalsSummary && (
+            <div className="mb-6">
+              <h4 className="font-medium mb-3">Vitals Summary</h4>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Measurement</TableHead>
+                    <TableHead>Min</TableHead>
+                    <TableHead>Avg</TableHead>
+                    <TableHead>Max</TableHead>
+                    <TableHead>Count</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {report.vitalsSummary.temperature && (
+                    <TableRow>
+                      <TableCell className="font-medium">Temperature (&deg;C)</TableCell>
+                      <TableCell>{report.vitalsSummary.temperature.min.toFixed(1)}</TableCell>
+                      <TableCell>{report.vitalsSummary.temperature.avg.toFixed(1)}</TableCell>
+                      <TableCell>{report.vitalsSummary.temperature.max.toFixed(1)}</TableCell>
+                      <TableCell>{report.vitalsSummary.temperature.count}</TableCell>
+                    </TableRow>
+                  )}
+                  {report.vitalsSummary.bloodPressure.systolic && (
+                    <TableRow>
+                      <TableCell className="font-medium">Systolic BP (mmHg)</TableCell>
+                      <TableCell>{report.vitalsSummary.bloodPressure.systolic.min}</TableCell>
+                      <TableCell>
+                        {report.vitalsSummary.bloodPressure.systolic.avg.toFixed(0)}
+                      </TableCell>
+                      <TableCell>{report.vitalsSummary.bloodPressure.systolic.max}</TableCell>
+                      <TableCell>{report.vitalsSummary.bloodPressure.systolic.count}</TableCell>
+                    </TableRow>
+                  )}
+                  {report.vitalsSummary.bloodPressure.diastolic && (
+                    <TableRow>
+                      <TableCell className="font-medium">Diastolic BP (mmHg)</TableCell>
+                      <TableCell>{report.vitalsSummary.bloodPressure.diastolic.min}</TableCell>
+                      <TableCell>
+                        {report.vitalsSummary.bloodPressure.diastolic.avg.toFixed(0)}
+                      </TableCell>
+                      <TableCell>{report.vitalsSummary.bloodPressure.diastolic.max}</TableCell>
+                      <TableCell>{report.vitalsSummary.bloodPressure.diastolic.count}</TableCell>
+                    </TableRow>
+                  )}
+                  {report.vitalsSummary.pulseRate && (
+                    <TableRow>
+                      <TableCell className="font-medium">Pulse Rate (bpm)</TableCell>
+                      <TableCell>{report.vitalsSummary.pulseRate.min}</TableCell>
+                      <TableCell>{report.vitalsSummary.pulseRate.avg.toFixed(0)}</TableCell>
+                      <TableCell>{report.vitalsSummary.pulseRate.max}</TableCell>
+                      <TableCell>{report.vitalsSummary.pulseRate.count}</TableCell>
+                    </TableRow>
+                  )}
+                  {report.vitalsSummary.respiratoryRate && (
+                    <TableRow>
+                      <TableCell className="font-medium">Respiratory Rate</TableCell>
+                      <TableCell>{report.vitalsSummary.respiratoryRate.min}</TableCell>
+                      <TableCell>{report.vitalsSummary.respiratoryRate.avg.toFixed(0)}</TableCell>
+                      <TableCell>{report.vitalsSummary.respiratoryRate.max}</TableCell>
+                      <TableCell>{report.vitalsSummary.respiratoryRate.count}</TableCell>
+                    </TableRow>
+                  )}
+                  {report.vitalsSummary.oxygenSaturation && (
+                    <TableRow>
+                      <TableCell className="font-medium">SpO2 (%)</TableCell>
+                      <TableCell>{report.vitalsSummary.oxygenSaturation.min}</TableCell>
+                      <TableCell>{report.vitalsSummary.oxygenSaturation.avg.toFixed(1)}</TableCell>
+                      <TableCell>{report.vitalsSummary.oxygenSaturation.max}</TableCell>
+                      <TableCell>{report.vitalsSummary.oxygenSaturation.count}</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+
+          {/* Alerts */}
+          {report.alerts && report.alerts.length > 0 && (
+            <div>
+              <h4 className="font-medium mb-3">Alerts</h4>
+              <div className="space-y-2">
+                {report.alerts.map((alert, i) => (
+                  <div key={i} className="flex items-center gap-3 p-3 rounded-lg border">
+                    <Badge
+                      variant={
+                        severityColor(alert.severity) as 'destructive' | 'secondary' | 'outline'
+                      }
+                    >
+                      {alert.severity}
+                    </Badge>
+                    <div>
+                      <p className="text-sm font-medium">{alert.type}</p>
+                      <p className="text-xs text-muted-foreground">{alert.message}</p>
+                    </div>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {new Date(alert.recordedAt).toLocaleTimeString()}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -56,3 +56,9 @@ export {
   useAccessLogs,
   useChangeLogs,
 } from './use-admin';
+export {
+  useDailyReport,
+  useDailySummary,
+  useDailyReportList,
+  useGenerateDailyReport,
+} from './use-daily-reports';

--- a/apps/frontend/src/hooks/use-daily-reports.ts
+++ b/apps/frontend/src/hooks/use-daily-reports.ts
@@ -1,0 +1,40 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { dailyReportApi } from '@/services';
+import type { ListDailyReportsParams } from '@/types';
+
+export function useDailyReport(admissionId: string, date: string) {
+  return useQuery({
+    queryKey: ['daily-report', admissionId, date],
+    queryFn: () => dailyReportApi.getReport(admissionId, date),
+    enabled: !!admissionId && !!date,
+  });
+}
+
+export function useDailySummary(admissionId: string, date: string) {
+  return useQuery({
+    queryKey: ['daily-summary', admissionId, date],
+    queryFn: () => dailyReportApi.getSummary(admissionId, date),
+    enabled: !!admissionId && !!date,
+  });
+}
+
+export function useDailyReportList(admissionId: string, params: ListDailyReportsParams = {}) {
+  return useQuery({
+    queryKey: ['daily-reports', admissionId, params],
+    queryFn: () => dailyReportApi.listReports(admissionId, params),
+    enabled: !!admissionId,
+  });
+}
+
+export function useGenerateDailyReport(admissionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (date: string) => dailyReportApi.generateReport(admissionId, date),
+    onSuccess: (_data, date) => {
+      queryClient.invalidateQueries({ queryKey: ['daily-report', admissionId, date] });
+      queryClient.invalidateQueries({ queryKey: ['daily-reports', admissionId] });
+      queryClient.invalidateQueries({ queryKey: ['daily-summary', admissionId, date] });
+    },
+  });
+}

--- a/apps/frontend/src/services/daily-report-api.ts
+++ b/apps/frontend/src/services/daily-report-api.ts
@@ -1,0 +1,42 @@
+import { apiGet, apiPost } from '@/lib/api-client';
+import type {
+  DailyReport,
+  DailySummary,
+  PaginatedDailyReports,
+  ListDailyReportsParams,
+} from '@/types';
+
+function buildQueryString(params: ListDailyReportsParams): string {
+  const searchParams = new URLSearchParams();
+
+  if (params.startDate) searchParams.set('startDate', params.startDate);
+  if (params.endDate) searchParams.set('endDate', params.endDate);
+  if (params.page) searchParams.set('page', params.page.toString());
+  if (params.limit) searchParams.set('limit', params.limit.toString());
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+}
+
+export const dailyReportApi = {
+  getReport: (admissionId: string, date: string): Promise<DailyReport | null> => {
+    return apiGet<DailyReport | null>(`/admissions/${admissionId}/daily-reports/${date}`);
+  },
+
+  generateReport: (admissionId: string, date: string): Promise<DailyReport> => {
+    return apiPost<DailyReport>(`/admissions/${admissionId}/daily-reports/${date}/generate`, {});
+  },
+
+  getSummary: (admissionId: string, date: string): Promise<DailySummary> => {
+    return apiGet<DailySummary>(`/admissions/${admissionId}/daily-reports/${date}/summary`);
+  },
+
+  listReports: (
+    admissionId: string,
+    params: ListDailyReportsParams = {},
+  ): Promise<PaginatedDailyReports> => {
+    return apiGet<PaginatedDailyReports>(
+      `/admissions/${admissionId}/daily-reports${buildQueryString(params)}`,
+    );
+  },
+};

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -8,3 +8,4 @@ export { medicationApi } from './medication-api';
 export { nursingNoteApi } from './nursing-note-api';
 export { intakeOutputApi } from './intake-output-api';
 export { adminUserApi, adminRoleApi, adminAuditApi } from './admin-api';
+export { dailyReportApi } from './daily-report-api';

--- a/apps/frontend/src/types/daily-report.ts
+++ b/apps/frontend/src/types/daily-report.ts
@@ -1,0 +1,118 @@
+export interface StatsSummary {
+  min: number;
+  max: number;
+  avg: number;
+  count: number;
+}
+
+export interface BloodPressureStats {
+  systolic: StatsSummary | null;
+  diastolic: StatsSummary | null;
+}
+
+export interface VitalsSummary {
+  measurementCount: number;
+  temperature: StatsSummary | null;
+  bloodPressure: BloodPressureStats;
+  pulseRate: StatsSummary | null;
+  respiratoryRate: StatsSummary | null;
+  oxygenSaturation: StatsSummary | null;
+  alertCount: number;
+}
+
+export interface IntakeBreakdown {
+  oral: number;
+  iv: number;
+  tubeFeeding: number;
+  other: number;
+  total: number;
+}
+
+export interface OutputBreakdown {
+  urine: number;
+  stool: number;
+  vomit: number;
+  drainage: number;
+  other: number;
+  total: number;
+}
+
+export type IOBalanceStatusType = 'NORMAL' | 'POSITIVE' | 'NEGATIVE';
+
+export interface IOBalanceSummary {
+  intake: IntakeBreakdown;
+  output: OutputBreakdown;
+  balance: number;
+  status: IOBalanceStatusType;
+}
+
+export interface MedicationCompliance {
+  scheduled: number;
+  administered: number;
+  held: number;
+  refused: number;
+  missed: number;
+  complianceRate: number;
+}
+
+export type AlertSeverity = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+export interface DailyAlert {
+  type: string;
+  severity: AlertSeverity;
+  value: number;
+  message: string;
+  recordedAt: string;
+}
+
+export interface SignificantNote {
+  id: string;
+  noteType: string;
+  summary: string;
+  recordedAt: string;
+}
+
+export type PatientStatus = 'STABLE' | 'IMPROVING' | 'DECLINING' | 'CRITICAL' | 'GUARDED' | 'FAIR';
+
+export interface DailyReport {
+  id: string;
+  admissionId: string;
+  reportDate: string;
+  vitalsSummary: VitalsSummary | null;
+  totalIntake: number | null;
+  totalOutput: number | null;
+  ioBalance: number | null;
+  medicationsGiven: number | null;
+  medicationsHeld: number | null;
+  patientStatus: PatientStatus | null;
+  summary: string | null;
+  alerts: DailyAlert[] | null;
+  generatedAt: string;
+  generatedBy: string | null;
+}
+
+export interface DailySummary {
+  admissionId: string;
+  date: string;
+  vitalsSummary: VitalsSummary | null;
+  ioBalance: IOBalanceSummary | null;
+  medicationCompliance: MedicationCompliance;
+  significantNotes: SignificantNote[];
+  alerts: DailyAlert[];
+  patientStatus: PatientStatus | null;
+}
+
+export interface PaginatedDailyReports {
+  data: DailyReport[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface ListDailyReportsParams {
+  startDate?: string;
+  endDate?: string;
+  page?: number;
+  limit?: number;
+}

--- a/apps/frontend/src/types/index.ts
+++ b/apps/frontend/src/types/index.ts
@@ -29,3 +29,4 @@ export * from './medication';
 export * from './nursing-note';
 export * from './intake-output';
 export * from './admin';
+export * from './daily-report';


### PR DESCRIPTION
## Summary
- Add daily report types, API service, and React Query hooks matching backend DTOs
- Create dashboard home page replacing the bare landing page with summary cards (patients, floors, active rounds, completed rounds) and quick access links
- Create daily reports page with patient/admission selector, live summary cards (vitals, I/O balance, medications, alerts), report history table, and detailed report view with vitals breakdown

## Related Issue
Closes #198

## Test Plan
- [ ] Dashboard home page loads with summary cards
- [ ] Quick access links navigate to correct pages
- [ ] Today's rounds section shows scheduled/active rounds
- [ ] Daily reports page allows patient and admission selection
- [ ] Live summary displays real-time data for selected date
- [ ] Generate button creates new daily report
- [ ] Report history table shows paginated results
- [ ] Report detail view shows vitals, I/O, medications, and alerts
- [ ] TypeScript compilation passes