### PR TITLE
feat(auth): implement token blacklisting and role crud endpoints

### DIFF
--- a/apps/backend/src/modules/admin/dto/user-admin.dto.ts
+++ b/apps/backend/src/modules/admin/dto/user-admin.dto.ts
@@ -410,3 +410,68 @@ export class MessageResponseDto {
     this.message = message;
   }
 }
+
+/**
+ * DTO for creating a new role
+ */
+export class CreateRoleDto {
+  @ApiProperty({ description: 'Unique role code', example: 'PHARMACIST' })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(50)
+  @Matches(/^[A-Z_]+$/, { message: 'Role code must be uppercase letters and underscores' })
+  code: string;
+
+  @ApiProperty({ description: 'Role display name', example: 'Pharmacist' })
+  @IsNotEmpty()
+  @IsString()
+  @MaxLength(100)
+  name: string;
+
+  @ApiPropertyOptional({ description: 'Role description' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'Role hierarchy level', default: 0 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  level?: number;
+}
+
+/**
+ * DTO for updating a role
+ */
+export class UpdateRoleDto {
+  @ApiPropertyOptional({ description: 'Role display name' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @ApiPropertyOptional({ description: 'Role description' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+
+  @ApiPropertyOptional({ description: 'Role hierarchy level' })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  level?: number;
+}
+
+/**
+ * DTO for adding permission to a role
+ */
+export class AddPermissionDto {
+  @ApiProperty({ description: 'Permission ID to add', format: 'uuid' })
+  @IsNotEmpty()
+  @IsUUID()
+  permissionId: string;
+}

--- a/apps/backend/src/modules/admin/exceptions.ts
+++ b/apps/backend/src/modules/admin/exceptions.ts
@@ -71,3 +71,30 @@ export class CannotRemoveLastAdminRoleException extends HttpException {
     super('Cannot remove the last admin role from the system', HttpStatus.FORBIDDEN);
   }
 }
+
+/**
+ * Exception thrown when attempting to create a role with duplicate code
+ */
+export class DuplicateRoleCodeException extends ConflictException {
+  constructor(code: string) {
+    super(`Role code already exists: ${code}`);
+  }
+}
+
+/**
+ * Exception thrown when attempting to delete a role that has assigned users
+ */
+export class RoleHasUsersException extends ConflictException {
+  constructor(roleId: string) {
+    super(`Cannot delete role ${roleId}: users are still assigned to this role`);
+  }
+}
+
+/**
+ * Exception thrown when a permission is not found
+ */
+export class PermissionNotFoundException extends NotFoundException {
+  constructor(identifier: string) {
+    super(`Permission not found: ${identifier}`);
+  }
+}

--- a/apps/backend/src/modules/admin/role.controller.ts
+++ b/apps/backend/src/modules/admin/role.controller.ts
@@ -1,10 +1,30 @@
-import { Controller, Get, Param, UseGuards, Logger, ParseUUIDPipe } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  Logger,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../common/guards';
 import { PermissionGuard } from '../auth/guards';
 import { RequireRole } from '../auth/decorators';
 import { RoleService } from './role.service';
-import { RoleResponseDto, RoleWithPermissionsDto } from './dto';
+import {
+  RoleResponseDto,
+  RoleWithPermissionsDto,
+  CreateRoleDto,
+  UpdateRoleDto,
+  AddPermissionDto,
+  MessageResponseDto,
+} from './dto';
 
 /**
  * Controller for role management
@@ -36,6 +56,21 @@ export class RoleController {
   }
 
   /**
+   * Create a new role
+   * POST /admin/roles
+   */
+  @ApiOperation({ summary: 'Create a new role' })
+  @ApiResponse({ status: 201, description: 'Role created', type: RoleResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 409, description: 'Role code already exists' })
+  @Post()
+  async create(@Body() dto: CreateRoleDto): Promise<RoleResponseDto> {
+    this.logger.log(`Creating role: ${dto.code}`);
+    return this.roleService.createRole(dto);
+  }
+
+  /**
    * Get role by ID
    * GET /admin/roles/:id
    */
@@ -49,6 +84,44 @@ export class RoleController {
   async findOne(@Param('id', ParseUUIDPipe) id: string): Promise<RoleResponseDto> {
     this.logger.log(`Getting role ${id}`);
     return this.roleService.getRoleById(id);
+  }
+
+  /**
+   * Update a role
+   * PATCH /admin/roles/:id
+   */
+  @ApiOperation({ summary: 'Update a role' })
+  @ApiParam({ name: 'id', description: 'Role ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Role updated', type: RoleResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Role not found' })
+  @Patch(':id')
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateRoleDto,
+  ): Promise<RoleResponseDto> {
+    this.logger.log(`Updating role ${id}`);
+    return this.roleService.updateRole(id, dto);
+  }
+
+  /**
+   * Delete a role
+   * DELETE /admin/roles/:id
+   */
+  @ApiOperation({ summary: 'Delete a role' })
+  @ApiParam({ name: 'id', description: 'Role ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Role deleted', type: MessageResponseDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Role not found' })
+  @ApiResponse({ status: 409, description: 'Role has assigned users' })
+  @Delete(':id')
+  @HttpCode(HttpStatus.OK)
+  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<MessageResponseDto> {
+    this.logger.log(`Deleting role ${id}`);
+    await this.roleService.deleteRole(id);
+    return new MessageResponseDto('Role deleted successfully');
   }
 
   /**
@@ -67,5 +140,46 @@ export class RoleController {
   ): Promise<RoleWithPermissionsDto> {
     this.logger.log(`Getting role ${id} with permissions`);
     return this.roleService.getRoleWithPermissions(id);
+  }
+
+  /**
+   * Add permission to a role
+   * POST /admin/roles/:id/permissions
+   */
+  @ApiOperation({ summary: 'Add permission to a role' })
+  @ApiParam({ name: 'id', description: 'Role ID', format: 'uuid' })
+  @ApiResponse({ status: 201, description: 'Permission added', type: RoleWithPermissionsDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Role or permission not found' })
+  @ApiResponse({ status: 409, description: 'Role already has this permission' })
+  @Post(':id/permissions')
+  async addPermission(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AddPermissionDto,
+  ): Promise<RoleWithPermissionsDto> {
+    this.logger.log(`Adding permission ${dto.permissionId} to role ${id}`);
+    return this.roleService.addPermission(id, dto.permissionId);
+  }
+
+  /**
+   * Remove permission from a role
+   * DELETE /admin/roles/:id/permissions/:permId
+   */
+  @ApiOperation({ summary: 'Remove permission from a role' })
+  @ApiParam({ name: 'id', description: 'Role ID', format: 'uuid' })
+  @ApiParam({ name: 'permId', description: 'Permission ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Permission removed', type: RoleWithPermissionsDto })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires ADMIN role' })
+  @ApiResponse({ status: 404, description: 'Role or permission not found' })
+  @Delete(':id/permissions/:permId')
+  @HttpCode(HttpStatus.OK)
+  async removePermission(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('permId', ParseUUIDPipe) permId: string,
+  ): Promise<RoleWithPermissionsDto> {
+    this.logger.log(`Removing permission ${permId} from role ${id}`);
+    return this.roleService.removePermission(id, permId);
   }
 }

--- a/apps/backend/src/modules/admin/role.repository.ts
+++ b/apps/backend/src/modules/admin/role.repository.ts
@@ -131,6 +131,96 @@ export class RoleRepository {
     const existingIds = new Set(existingRoles.map((r) => r.id));
     return roleIds.filter((id) => !existingIds.has(id));
   }
+
+  /**
+   * Create a new role
+   */
+  async create(data: {
+    code: string;
+    name: string;
+    description?: string;
+    level?: number;
+  }): Promise<Role> {
+    return this.prisma.role.create({
+      data: {
+        code: data.code,
+        name: data.name,
+        description: data.description ?? null,
+        level: data.level ?? 0,
+        isActive: true,
+      },
+    });
+  }
+
+  /**
+   * Update a role
+   */
+  async update(
+    id: string,
+    data: { name?: string; description?: string; level?: number; isActive?: boolean },
+  ): Promise<Role> {
+    return this.prisma.role.update({
+      where: { id },
+      data,
+    });
+  }
+
+  /**
+   * Delete a role
+   */
+  async delete(id: string): Promise<void> {
+    await this.prisma.role.delete({
+      where: { id },
+    });
+  }
+
+  /**
+   * Count users assigned to a role
+   */
+  async countUsersWithRole(roleId: string): Promise<number> {
+    return this.prisma.userRole.count({
+      where: { roleId },
+    });
+  }
+
+  /**
+   * Add permission to role
+   */
+  async addPermission(roleId: string, permissionId: string): Promise<void> {
+    await this.prisma.rolePermission.create({
+      data: { roleId, permissionId },
+    });
+  }
+
+  /**
+   * Remove permission from role
+   */
+  async removePermission(roleId: string, permissionId: string): Promise<void> {
+    await this.prisma.rolePermission.delete({
+      where: {
+        roleId_permissionId: { roleId, permissionId },
+      },
+    });
+  }
+
+  /**
+   * Find permission by ID
+   */
+  async findPermissionById(id: string): Promise<Permission | null> {
+    return this.prisma.permission.findUnique({
+      where: { id },
+    });
+  }
+
+  /**
+   * Check if role-permission mapping exists
+   */
+  async hasPermission(roleId: string, permissionId: string): Promise<boolean> {
+    const count = await this.prisma.rolePermission.count({
+      where: { roleId, permissionId },
+    });
+    return count > 0;
+  }
 }
 
 /**

--- a/apps/backend/src/modules/admin/role.service.ts
+++ b/apps/backend/src/modules/admin/role.service.ts
@@ -1,7 +1,13 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, ConflictException } from '@nestjs/common';
 import { RoleRepository, RoleWithPermissions } from './role.repository';
 import { RoleResponseDto, RoleWithPermissionsDto, PermissionDto } from './dto';
-import { RoleNotFoundException } from './exceptions';
+import {
+  RoleNotFoundException,
+  DuplicateRoleCodeException,
+  RoleHasUsersException,
+  PermissionNotFoundException,
+} from './exceptions';
+import { RbacService } from '../auth/services';
 
 /**
  * Service for role operations
@@ -12,7 +18,10 @@ import { RoleNotFoundException } from './exceptions';
 export class RoleService {
   private readonly logger = new Logger(RoleService.name);
 
-  constructor(private readonly roleRepo: RoleRepository) {}
+  constructor(
+    private readonly roleRepo: RoleRepository,
+    private readonly rbacService: RbacService,
+  ) {}
 
   /**
    * Get all roles
@@ -50,6 +59,114 @@ export class RoleService {
   async listRolesWithPermissions(): Promise<RoleWithPermissionsDto[]> {
     const roles = await this.roleRepo.findAllWithPermissions();
     return roles.map((role) => this.mapRoleWithPermissionsToResponse(role));
+  }
+
+  /**
+   * Create a new role
+   */
+  async createRole(data: {
+    code: string;
+    name: string;
+    description?: string;
+    level?: number;
+  }): Promise<RoleResponseDto> {
+    const existing = await this.roleRepo.findByCode(data.code);
+    if (existing) {
+      throw new DuplicateRoleCodeException(data.code);
+    }
+
+    const role = await this.roleRepo.create(data);
+    this.logger.log(`Role created: ${role.code}`);
+    return this.mapRoleToResponse(role);
+  }
+
+  /**
+   * Update a role
+   */
+  async updateRole(
+    id: string,
+    data: { name?: string; description?: string; level?: number },
+  ): Promise<RoleResponseDto> {
+    const role = await this.roleRepo.findById(id);
+    if (!role) {
+      throw new RoleNotFoundException(id);
+    }
+
+    const updated = await this.roleRepo.update(id, data);
+    await this.rbacService.invalidateAllCaches();
+    this.logger.log(`Role updated: ${updated.code}`);
+    return this.mapRoleToResponse(updated);
+  }
+
+  /**
+   * Delete a role (only if no users are assigned)
+   */
+  async deleteRole(id: string): Promise<void> {
+    const role = await this.roleRepo.findById(id);
+    if (!role) {
+      throw new RoleNotFoundException(id);
+    }
+
+    const userCount = await this.roleRepo.countUsersWithRole(id);
+    if (userCount > 0) {
+      throw new RoleHasUsersException(id);
+    }
+
+    await this.roleRepo.delete(id);
+    await this.rbacService.invalidateAllCaches();
+    this.logger.log(`Role deleted: ${role.code}`);
+  }
+
+  /**
+   * Add permission to a role
+   */
+  async addPermission(roleId: string, permissionId: string): Promise<RoleWithPermissionsDto> {
+    const role = await this.roleRepo.findById(roleId);
+    if (!role) {
+      throw new RoleNotFoundException(roleId);
+    }
+
+    const permission = await this.roleRepo.findPermissionById(permissionId);
+    if (!permission) {
+      throw new PermissionNotFoundException(permissionId);
+    }
+
+    const hasPermission = await this.roleRepo.hasPermission(roleId, permissionId);
+    if (hasPermission) {
+      throw new ConflictException(`Role already has permission: ${permission.code}`);
+    }
+
+    await this.roleRepo.addPermission(roleId, permissionId);
+    await this.rbacService.invalidateAllCaches();
+    this.logger.log(`Permission ${permission.code} added to role ${role.code}`);
+
+    return this.getRoleWithPermissions(roleId);
+  }
+
+  /**
+   * Remove permission from a role
+   */
+  async removePermission(roleId: string, permissionId: string): Promise<RoleWithPermissionsDto> {
+    const role = await this.roleRepo.findById(roleId);
+    if (!role) {
+      throw new RoleNotFoundException(roleId);
+    }
+
+    const permission = await this.roleRepo.findPermissionById(permissionId);
+    if (!permission) {
+      throw new PermissionNotFoundException(permissionId);
+    }
+
+    const hasPermission = await this.roleRepo.hasPermission(roleId, permissionId);
+    if (!hasPermission) {
+      throw new ConflictException(`Role does not have permission: ${permission.code}`);
+    }
+
+    await this.roleRepo.removePermission(roleId, permissionId);
+    await this.rbacService.invalidateAllCaches();
+    this.logger.log(`Permission ${permission.code} removed from role ${role.code}`);
+
+    return this.getRoleWithPermissions(roleId);
   }
 
   /**

--- a/apps/backend/src/modules/auth/auth.module.ts
+++ b/apps/backend/src/modules/auth/auth.module.ts
@@ -2,7 +2,13 @@ import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { SessionService, JwtTokenService, AuthService, RbacService } from './services';
+import {
+  SessionService,
+  JwtTokenService,
+  AuthService,
+  RbacService,
+  TokenBlacklistService,
+} from './services';
 import { SessionActivityInterceptor } from './interceptors';
 import { JwtStrategy, LocalStrategy } from './strategies';
 import { LocalAuthGuard, PermissionGuard, ResourceAccessGuard } from './guards';
@@ -30,6 +36,7 @@ import { PrismaModule } from '../../prisma';
     JwtTokenService,
     AuthService,
     RbacService,
+    TokenBlacklistService,
     SessionActivityInterceptor,
     JwtStrategy,
     LocalStrategy,
@@ -44,6 +51,7 @@ import { PrismaModule } from '../../prisma';
     JwtTokenService,
     AuthService,
     RbacService,
+    TokenBlacklistService,
     SessionActivityInterceptor,
     PermissionGuard,
     ResourceAccessGuard,

--- a/apps/backend/src/modules/auth/services/auth.service.ts
+++ b/apps/backend/src/modules/auth/services/auth.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, UnauthorizedException, ForbiddenException } from '@
 import { User } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../../../prisma';
-import { SessionService, JwtTokenService } from './';
+import { SessionService, JwtTokenService, TokenBlacklistService } from './';
 import { TokenPair, DeviceInfo, CreateSessionInput } from '../interfaces';
 import { LoginResponseDto, TokenResponseDto, UserInfoDto, ChangePasswordDto } from '../dto';
 
@@ -11,11 +11,13 @@ export class AuthService {
   private readonly logger = new Logger(AuthService.name);
   private readonly MAX_FAILED_ATTEMPTS = 5;
   private readonly LOCK_DURATION_MINUTES = 30;
+  private readonly MAX_TOKEN_TTL_SECONDS = 7 * 24 * 3600; // 7 days (refresh token lifetime)
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly sessionService: SessionService,
     private readonly jwtTokenService: JwtTokenService,
+    private readonly tokenBlacklistService: TokenBlacklistService,
   ) {}
 
   /**
@@ -113,11 +115,12 @@ export class AuthService {
   }
 
   /**
-   * Logout from all sessions
+   * Logout from all sessions and revoke all tokens
    */
   async logoutAll(userId: string): Promise<void> {
     await this.sessionService.destroyAllForUser(userId);
-    this.logger.log(`All sessions destroyed for user ${userId}`);
+    await this.tokenBlacklistService.revokeAllForUser(userId, this.MAX_TOKEN_TTL_SECONDS);
+    this.logger.log(`All sessions destroyed and tokens revoked for user ${userId}`);
   }
 
   /**
@@ -190,7 +193,11 @@ export class AuthService {
       },
     });
 
-    this.logger.log(`Password changed for user ${user.username}`);
+    // Invalidate all existing tokens and sessions after password change
+    await this.sessionService.destroyAllForUser(userId);
+    await this.tokenBlacklistService.revokeAllForUser(userId, this.MAX_TOKEN_TTL_SECONDS);
+
+    this.logger.log(`Password changed and all tokens revoked for user ${user.username}`);
   }
 
   /**

--- a/apps/backend/src/modules/auth/services/index.ts
+++ b/apps/backend/src/modules/auth/services/index.ts
@@ -2,3 +2,4 @@ export * from './session.service';
 export * from './jwt-token.service';
 export * from './auth.service';
 export * from './rbac.service';
+export * from './token-blacklist.service';

--- a/apps/backend/src/modules/auth/services/token-blacklist.service.ts
+++ b/apps/backend/src/modules/auth/services/token-blacklist.service.ts
@@ -1,0 +1,57 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import Redis from 'ioredis';
+
+@Injectable()
+export class TokenBlacklistService {
+  private readonly logger = new Logger(TokenBlacklistService.name);
+  private readonly BLACKLIST_PREFIX = 'token_blacklist:';
+
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  /**
+   * Add a token to the blacklist with its remaining TTL
+   */
+  async blacklist(tokenJti: string, expiresInSeconds: number): Promise<void> {
+    if (expiresInSeconds <= 0) {
+      return;
+    }
+
+    const key = `${this.BLACKLIST_PREFIX}${tokenJti}`;
+    await this.redis.set(key, '1', 'EX', expiresInSeconds);
+    this.logger.log(`Token blacklisted: ${tokenJti} (TTL: ${expiresInSeconds}s)`);
+  }
+
+  /**
+   * Check if a token is blacklisted
+   */
+  async isBlacklisted(tokenJti: string): Promise<boolean> {
+    const key = `${this.BLACKLIST_PREFIX}${tokenJti}`;
+    const exists = await this.redis.exists(key);
+    return exists === 1;
+  }
+
+  /**
+   * Blacklist all tokens for a user by storing a "revoke before" timestamp
+   */
+  async revokeAllForUser(userId: string, ttlSeconds: number): Promise<void> {
+    const key = `${this.BLACKLIST_PREFIX}user:${userId}`;
+    const revokedAt = Math.floor(Date.now() / 1000);
+    await this.redis.set(key, revokedAt.toString(), 'EX', ttlSeconds);
+    this.logger.log(`All tokens revoked for user: ${userId}`);
+  }
+
+  /**
+   * Check if a user's tokens issued before a certain time are revoked
+   */
+  async isUserTokenRevoked(userId: string, tokenIssuedAt: number): Promise<boolean> {
+    const key = `${this.BLACKLIST_PREFIX}user:${userId}`;
+    const revokedAt = await this.redis.get(key);
+
+    if (!revokedAt) {
+      return false;
+    }
+
+    return tokenIssuedAt <= parseInt(revokedAt, 10);
+  }
+}

--- a/apps/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/apps/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -2,7 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
-import { SessionService } from '../services';
+import { SessionService, TokenBlacklistService } from '../services';
 import { TokenPayload, AuthenticatedUser } from '../interfaces';
 
 @Injectable()
@@ -10,6 +10,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(
     private readonly configService: ConfigService,
     private readonly sessionService: SessionService,
+    private readonly tokenBlacklistService: TokenBlacklistService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -19,9 +20,20 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   /**
-   * Validate JWT payload and check session validity
+   * Validate JWT payload, check blacklist, and verify session
    */
   async validate(payload: TokenPayload): Promise<AuthenticatedUser> {
+    // Check if all user tokens are revoked (password change, account deactivation)
+    if (payload.iat) {
+      const isRevoked = await this.tokenBlacklistService.isUserTokenRevoked(
+        payload.sub,
+        payload.iat,
+      );
+      if (isRevoked) {
+        throw new UnauthorizedException('Token has been revoked');
+      }
+    }
+
     const isSessionValid = await this.sessionService.isValid(payload.sessionId);
 
     if (!isSessionValid) {


### PR DESCRIPTION
## Summary
- Implement Redis-based token blacklisting service (`TokenBlacklistService`) with per-token JTI and per-user revocation
- Integrate blacklist validation into `JwtStrategy.validate()` to reject revoked tokens immediately
- Automatically revoke all tokens on `logoutAll()` and `changePassword()` operations
- Add full CRUD endpoints for role management: `POST /admin/roles`, `PATCH /admin/roles/:id`, `DELETE /admin/roles/:id`
- Add role permission management: `POST /admin/roles/:id/permissions`, `DELETE /admin/roles/:id/permissions/:permId`
- Enforce role deletion protection when users are still assigned
- Invalidate RBAC permission cache on all role/permission modifications

## Related Issue
Closes #200

## Test Plan
- [ ] Logged-out tokens return 401 immediately after logout-all
- [ ] Password change invalidates all existing sessions and tokens
- [ ] POST /admin/roles creates new role with validation
- [ ] PATCH /admin/roles/:id updates role properties
- [ ] DELETE /admin/roles/:id fails when users are assigned (409)
- [ ] DELETE /admin/roles/:id succeeds when no users assigned
- [ ] POST /admin/roles/:id/permissions adds permission to role
- [ ] DELETE /admin/roles/:id/permissions/:permId removes permission
- [ ] RBAC cache is refreshed after permission changes
- [ ] TypeScript compilation passes