### PR TITLE
feat(database): add missing indexes for frequently queried fields

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -428,8 +428,11 @@ model Admission {
   @@index([bedId])
   @@index([status])
   @@index([attendingDoctorId])
+  @@index([primaryNurseId])
+  @@index([createdBy])
   @@index([admissionDate])
   @@index([patientId, status])
+  @@index([bedId, status])
   @@map("admissions")
   @@schema("admission")
 }
@@ -456,6 +459,7 @@ model Transfer {
   @@index([admissionId])
   @@index([fromBedId])
   @@index([toBedId])
+  @@index([transferredBy])
   @@index([transferDate])
   @@map("transfers")
   @@schema("admission")
@@ -479,6 +483,7 @@ model Discharge {
   admission  Admission @relation(fields: [admissionId], references: [id], onDelete: Restrict)
   discharger User      @relation("Discharger", fields: [dischargedBy], references: [id], onDelete: Restrict)
 
+  @@index([dischargedBy])
   @@index([dischargeDate])
   @@map("discharges")
   @@schema("admission")
@@ -582,6 +587,7 @@ model VitalSign {
   measurer  User      @relation("VitalSignMeasurer", fields: [measuredBy], references: [id], onDelete: Restrict)
 
   @@index([admissionId, measuredAt(sort: Desc)])
+  @@index([measuredAt])
   @@index([hasAlert])
   @@index([measuredBy])
   @@map("vital_signs")
@@ -643,6 +649,8 @@ model Medication {
 
   @@index([admissionId, administeredAt])
   @@index([admissionId, status])
+  @@index([medicationName])
+  @@index([scheduledTime])
   @@index([administeredBy])
   @@map("medications")
   @@schema("report")
@@ -671,6 +679,7 @@ model NursingNote {
 
   @@index([admissionId, recordedAt(sort: Desc)])
   @@index([admissionId, noteType])
+  @@index([recordedAt])
   @@index([recordedBy])
   @@index([isSignificant])
   @@map("nursing_notes")
@@ -753,6 +762,8 @@ model LoginHistory {
 
   @@index([userId, loginAt(sort: Desc)])
   @@index([ipAddress, loginAt(sort: Desc)])
+  @@index([sessionId])
+  @@index([success])
   @@index([createdAt(sort: Desc)])
   @@map("login_history")
   @@schema("audit")
@@ -884,6 +895,7 @@ model Round {
   @@index([floorId, scheduledDate])
   @@index([status])
   @@index([leadDoctorId])
+  @@index([createdBy])
   @@index([scheduledDate])
   @@index([roundType])
   @@map("rounds")
@@ -916,6 +928,7 @@ model RoundRecord {
   @@unique([roundId, admissionId])
   @@index([roundId])
   @@index([admissionId])
+  @@index([visitedAt])
   @@index([recordedBy])
   @@index([roundId, visitOrder])
   @@map("round_records")


### PR DESCRIPTION
## Summary
- Add 14 missing `@@index` declarations to Prisma schema for foreign key and filter columns that lacked database indexes
- Prevents full table scans as data grows for commonly queried patterns (nurse assignments, audit trails, time-range queries, bed occupancy checks)

## Changes
| Model | New Index | Query Pattern |
|-------|-----------|---------------|
| Admission | `primaryNurseId` | Nurse querying assigned patients |
| Admission | `createdBy` | Audit trail by creator |
| Admission | `bedId, status` (composite) | Bed occupancy checks |
| Transfer | `transferredBy` | Audit queries |
| Discharge | `dischargedBy` | Audit queries |
| LoginHistory | `sessionId` | Session-based lookups |
| LoginHistory | `success` | Failed login monitoring |
| VitalSign | `measuredAt` | Cross-admission time-range queries |
| Medication | `medicationName` | Search by medication |
| Medication | `scheduledTime` | Scheduling queries |
| NursingNote | `recordedAt` | Cross-admission time queries |
| Round | `createdBy` | Audit queries |
| RoundRecord | `visitedAt` | Time-based queries |

## Test Plan
- [x] Prisma schema validates successfully
- [x] TypeScript compilation passes
- [ ] Migration runs successfully in staging
- [ ] Common query patterns show index usage in EXPLAIN output

Closes #201