### PR TITLE
feat(admission): change time fields from varchar to postgresql time type

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -394,7 +394,7 @@ model Admission {
   bedId                 String          @map("bed_id") @db.Uuid
   admissionNumber       String          @unique @map("admission_number") @db.VarChar(20)
   admissionDate         DateTime        @map("admission_date") @db.Date
-  admissionTime         String          @map("admission_time") @db.VarChar(10)
+  admissionTime         DateTime        @map("admission_time") @db.Time
   admissionType         AdmissionType   @map("admission_type")
   diagnosis             String?         @db.Text
   chiefComplaint        String?         @map("chief_complaint") @db.Text
@@ -444,7 +444,7 @@ model Transfer {
   fromBedId     String   @map("from_bed_id") @db.Uuid
   toBedId       String   @map("to_bed_id") @db.Uuid
   transferDate  DateTime @map("transfer_date") @db.Date
-  transferTime  String   @map("transfer_time") @db.VarChar(10)
+  transferTime  DateTime @map("transfer_time") @db.Time
   reason        String   @db.VarChar(255)
   notes         String?  @db.Text
   transferredBy String   @map("transferred_by") @db.Uuid
@@ -470,7 +470,7 @@ model Discharge {
   id                   String        @id @default(uuid()) @db.Uuid
   admissionId          String        @unique @map("admission_id") @db.Uuid
   dischargeDate        DateTime      @map("discharge_date") @db.Date
-  dischargeTime        String        @map("discharge_time") @db.VarChar(10)
+  dischargeTime        DateTime      @map("discharge_time") @db.Time
   dischargeType        DischargeType @map("discharge_type")
   dischargeDiagnosis   String?       @map("discharge_diagnosis") @db.Text
   dischargeSummary     String?       @map("discharge_summary") @db.Text

--- a/apps/backend/src/modules/admission/admission.repository.ts
+++ b/apps/backend/src/modules/admission/admission.repository.ts
@@ -15,7 +15,7 @@ export interface CreateAdmissionData {
   bedId: string;
   admissionNumber: string;
   admissionDate: Date;
-  admissionTime: string;
+  admissionTime: Date;
   admissionType: AdmissionType;
   diagnosis?: string;
   chiefComplaint?: string;
@@ -43,7 +43,7 @@ export interface CreateTransferData {
   fromBedId: string;
   toBedId: string;
   transferDate: Date;
-  transferTime: string;
+  transferTime: Date;
   reason: string;
   notes?: string;
   transferredBy: string;
@@ -52,7 +52,7 @@ export interface CreateTransferData {
 export interface CreateDischargeData {
   admissionId: string;
   dischargeDate: Date;
-  dischargeTime: string;
+  dischargeTime: Date;
   dischargeType: DischargeType;
   dischargeDiagnosis?: string;
   dischargeSummary?: string;

--- a/apps/backend/src/modules/admission/admission.service.ts
+++ b/apps/backend/src/modules/admission/admission.service.ts
@@ -32,6 +32,16 @@ export class AdmissionService {
     private readonly prisma: PrismaService,
   ) {}
 
+  private parseTime(timeStr: string): Date {
+    return new Date(`1970-01-01T${timeStr}:00.000Z`);
+  }
+
+  private formatTime(date: Date): string {
+    const hours = date.getUTCHours().toString().padStart(2, '0');
+    const minutes = date.getUTCMinutes().toString().padStart(2, '0');
+    return `${hours}:${minutes}`;
+  }
+
   async admitPatient(dto: CreateAdmissionDto, userId: string): Promise<AdmissionResponseDto> {
     const patient = await this.prisma.patient.findFirst({
       where: { id: dto.patientId, deletedAt: null },
@@ -59,7 +69,7 @@ export class AdmissionService {
           bedId: dto.bedId,
           admissionNumber,
           admissionDate: new Date(dto.admissionDate),
-          admissionTime: dto.admissionTime,
+          admissionTime: this.parseTime(dto.admissionTime),
           admissionType: dto.admissionType,
           diagnosis: dto.diagnosis,
           chiefComplaint: dto.chiefComplaint,
@@ -117,7 +127,7 @@ export class AdmissionService {
           fromBedId: oldBedId,
           toBedId: dto.toBedId,
           transferDate: new Date(dto.transferDate),
-          transferTime: dto.transferTime,
+          transferTime: this.parseTime(dto.transferTime),
           reason: dto.reason,
           notes: dto.notes,
           transferredBy: userId,
@@ -174,7 +184,7 @@ export class AdmissionService {
         data: {
           admissionId,
           dischargeDate: new Date(dto.dischargeDate),
-          dischargeTime: dto.dischargeTime,
+          dischargeTime: this.parseTime(dto.dischargeTime),
           dischargeType: dto.dischargeType,
           dischargeDiagnosis: dto.dischargeDiagnosis,
           dischargeSummary: dto.dischargeSummary,
@@ -271,7 +281,7 @@ export class AdmissionService {
       bedId: admission.bedId,
       admissionNumber: admission.admissionNumber,
       admissionDate: admission.admissionDate,
-      admissionTime: admission.admissionTime,
+      admissionTime: this.formatTime(admission.admissionTime),
       admissionType: admission.admissionType,
       diagnosis: admission.diagnosis,
       chiefComplaint: admission.chiefComplaint,
@@ -295,7 +305,7 @@ export class AdmissionService {
       fromBedId: transfer.fromBedId,
       toBedId: transfer.toBedId,
       transferDate: transfer.transferDate,
-      transferTime: transfer.transferTime,
+      transferTime: this.formatTime(transfer.transferTime),
       reason: transfer.reason,
       notes: transfer.notes,
       transferredBy: transfer.transferredBy,
@@ -308,7 +318,7 @@ export class AdmissionService {
       id: discharge.id,
       admissionId: discharge.admissionId,
       dischargeDate: discharge.dischargeDate,
-      dischargeTime: discharge.dischargeTime,
+      dischargeTime: this.formatTime(discharge.dischargeTime),
       dischargeType: discharge.dischargeType,
       dischargeDiagnosis: discharge.dischargeDiagnosis,
       dischargeSummary: discharge.dischargeSummary,

--- a/apps/backend/test/factories/admission.factory.ts
+++ b/apps/backend/test/factories/admission.factory.ts
@@ -17,7 +17,9 @@ export function createTestAdmission(overrides?: Partial<Admission>): Admission {
     bedId: faker.string.uuid(),
     admissionNumber: `A${year}${faker.string.numeric(6)}`,
     admissionDate: now,
-    admissionTime: `${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:${faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')}`,
+    admissionTime: new Date(
+      `1970-01-01T${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:${faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')}:00.000Z`,
+    ),
     admissionType: faker.helpers.arrayElement([
       'SCHEDULED',
       'EMERGENCY',
@@ -33,6 +35,7 @@ export function createTestAdmission(overrides?: Partial<Admission>): Admission {
     createdAt: now,
     updatedAt: now,
     createdBy: faker.string.uuid(),
+    deletedAt: null,
     ...overrides,
   };
 }
@@ -45,7 +48,9 @@ export function createTestTransfer(overrides?: Partial<Transfer>): Transfer {
     fromBedId: faker.string.uuid(),
     toBedId: faker.string.uuid(),
     transferDate: now,
-    transferTime: `${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:${faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')}`,
+    transferTime: new Date(
+      `1970-01-01T${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:${faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')}:00.000Z`,
+    ),
     reason: faker.lorem.sentence(),
     notes: faker.lorem.sentence(),
     transferredBy: faker.string.uuid(),
@@ -60,7 +65,9 @@ export function createTestDischarge(overrides?: Partial<Discharge>): Discharge {
     id: faker.string.uuid(),
     admissionId: faker.string.uuid(),
     dischargeDate: now,
-    dischargeTime: `${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:${faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')}`,
+    dischargeTime: new Date(
+      `1970-01-01T${faker.number.int({ min: 0, max: 23 }).toString().padStart(2, '0')}:${faker.number.int({ min: 0, max: 59 }).toString().padStart(2, '0')}:00.000Z`,
+    ),
     dischargeType: faker.helpers.arrayElement([
       'NORMAL',
       'AMA',

--- a/apps/backend/test/integration/test-database.ts
+++ b/apps/backend/test/integration/test-database.ts
@@ -640,7 +640,7 @@ export async function createTestAdmission(
       bedId,
       admissionNumber,
       admissionDate: new Date(),
-      admissionTime: '14:30',
+      admissionTime: new Date('1970-01-01T14:30:00.000Z'),
       admissionType: AdmissionType.SCHEDULED,
       diagnosis: 'Test diagnosis',
       chiefComplaint: 'Test chief complaint',


### PR DESCRIPTION
## Summary
- Update `admissionTime`, `transferTime`, and `dischargeTime` fields from `String @db.VarChar(10)` to `DateTime @db.Time` for proper time-based queries, sorting, and comparisons
- Add `parseTime`/`formatTime` helper methods in `AdmissionService` for string-Date conversion
- API maintains backward compatibility: still accepts and returns `HH:mm` string format

## Changes
| File | Change |
|------|--------|
| `prisma/schema.prisma` | 3 fields: `VarChar(10)` → `@db.Time` |
| `admission.service.ts` | Add time conversion helpers, convert on write/read |
| `admission.repository.ts` | Update interfaces: `string` → `Date` |
| `test/factories/admission.factory.ts` | Generate Date objects instead of strings |
| `test/integration/test-database.ts` | Use Date for direct DB writes |

## Test Plan
- [x] Prisma schema validates successfully
- [x] TypeScript compilation passes (no new errors)
- [ ] Unit tests pass
- [ ] E2E tests pass with time-based sorting verification
- [ ] Migration with data conversion tested in staging

Closes #202