### PR TITLE
feat(backend): add global exception filter for all error types

### DIFF
--- a/apps/backend/src/common/filters/all-exceptions.filter.ts
+++ b/apps/backend/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,96 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Prisma } from '@prisma/client';
+
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const { status, message } = this.resolveException(exception);
+
+    this.logger.error(
+      `${request.method} ${request.url} → ${status}`,
+      exception instanceof Error ? exception.stack : String(exception),
+    );
+
+    response.status(status).json({
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      method: request.method,
+      message,
+    });
+  }
+
+  private resolveException(exception: unknown): {
+    status: number;
+    message: string | string[];
+  } {
+    if (exception instanceof HttpException) {
+      const exceptionResponse = exception.getResponse();
+      const message =
+        typeof exceptionResponse === 'string'
+          ? exceptionResponse
+          : (exceptionResponse as Record<string, unknown>).message || exception.message;
+      return {
+        status: exception.getStatus(),
+        message: message as string | string[],
+      };
+    }
+
+    if (exception instanceof Prisma.PrismaClientKnownRequestError) {
+      return this.resolvePrismaError(exception);
+    }
+
+    if (exception instanceof Prisma.PrismaClientInitializationError) {
+      return {
+        status: HttpStatus.SERVICE_UNAVAILABLE,
+        message: 'Database service is temporarily unavailable',
+      };
+    }
+
+    return {
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'An unexpected error occurred',
+    };
+  }
+
+  private resolvePrismaError(exception: Prisma.PrismaClientKnownRequestError): {
+    status: number;
+    message: string;
+  } {
+    switch (exception.code) {
+      case 'P2002':
+        return {
+          status: HttpStatus.CONFLICT,
+          message: 'A record with the given unique constraint already exists',
+        };
+      case 'P2025':
+        return {
+          status: HttpStatus.NOT_FOUND,
+          message: 'The requested record was not found',
+        };
+      case 'P2003':
+        return {
+          status: HttpStatus.BAD_REQUEST,
+          message: 'A related record was not found',
+        };
+      default:
+        return {
+          status: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'A database error occurred',
+        };
+    }
+  }
+}

--- a/apps/backend/src/common/filters/index.ts
+++ b/apps/backend/src/common/filters/index.ts
@@ -1,1 +1,2 @@
+export * from './all-exceptions.filter';
 export * from './http-exception.filter';

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -3,6 +3,7 @@ import { ValidationPipe, Logger } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './common/filters';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -16,6 +17,8 @@ async function bootstrap() {
     methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['Content-Type', 'Authorization'],
   });
+
+  app.useGlobalFilters(new AllExceptionsFilter());
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
## Summary
- Create `AllExceptionsFilter` with `@Catch()` to handle all unhandled exceptions
- Map Prisma client errors to appropriate HTTP status codes (P2002→409, P2025→404, P2003→400)
- Handle database initialization errors as 503 Service Unavailable
- Sanitize error responses — never expose stack traces or internal details to clients
- Remove `request.url` from error response body to prevent API structure leakage
- Log full error details server-side while returning generic messages to clients
- Register as global filter in `main.ts`

Closes #205

## Test Plan
- [ ] Verify Prisma unique constraint violations return 409 Conflict
- [ ] Verify Prisma not found errors return 404
- [ ] Verify unexpected errors return 500 with no stack trace
- [ ] Verify database connection errors return 503
- [ ] Verify existing HttpException behavior is preserved