### PR TITLE
feat(frontend): add missing write api wrappers for patient and admission

### DIFF
--- a/apps/frontend/src/hooks/index.ts
+++ b/apps/frontend/src/hooks/index.ts
@@ -1,5 +1,14 @@
 export { useFormWithZod } from './use-form-with-zod';
-export { usePatients, usePatient, usePatientSearch, useCreatePatient } from './use-patients';
+export {
+  usePatients,
+  usePatient,
+  usePatientSearch,
+  useCreatePatient,
+  useUpdatePatient,
+  useDeletePatient,
+  useCreatePatientDetail,
+  useUpdatePatientDetail,
+} from './use-patients';
 export {
   usePatientAdmissions,
   useAdmission,

--- a/apps/frontend/src/hooks/use-patients.ts
+++ b/apps/frontend/src/hooks/use-patients.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { patientApi } from '@/services';
-import type { FindPatientsParams, CreatePatientData } from '@/types';
+import type { FindPatientsParams, CreatePatientData, CreatePatientDetailData } from '@/types';
 
 export function usePatients(params: FindPatientsParams = {}) {
   return useQuery({
@@ -32,6 +32,59 @@ export function useCreatePatient() {
     mutationFn: (data: CreatePatientData) => patientApi.create(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['patients'] });
+    },
+  });
+}
+
+export function useUpdatePatient() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Partial<CreatePatientData> }) =>
+      patientApi.update(id, data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['patients'] });
+      queryClient.invalidateQueries({ queryKey: ['patient', variables.id] });
+    },
+  });
+}
+
+export function useDeletePatient() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => patientApi.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['patients'] });
+    },
+  });
+}
+
+export function useCreatePatientDetail() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ patientId, data }: { patientId: string; data: CreatePatientDetailData }) =>
+      patientApi.createDetail(patientId, data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['patient', variables.patientId] });
+    },
+  });
+}
+
+export function useUpdatePatientDetail() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      patientId,
+      data,
+    }: {
+      patientId: string;
+      data: Partial<CreatePatientDetailData>;
+    }) => patientApi.updateDetail(patientId, data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['patient', variables.patientId] });
     },
   });
 }

--- a/apps/frontend/src/services/patient-api.ts
+++ b/apps/frontend/src/services/patient-api.ts
@@ -1,5 +1,12 @@
-import { apiGet, apiPost, apiPatch } from '@/lib/api-client';
-import type { Patient, PaginatedPatients, FindPatientsParams, CreatePatientData } from '@/types';
+import { apiGet, apiPost, apiPatch, apiDelete } from '@/lib/api-client';
+import type {
+  Patient,
+  PatientDetail,
+  PaginatedPatients,
+  FindPatientsParams,
+  CreatePatientData,
+  CreatePatientDetailData,
+} from '@/types';
 
 function buildQueryString(params: FindPatientsParams): string {
   const searchParams = new URLSearchParams();
@@ -40,5 +47,20 @@ export const patientApi = {
 
   update: (id: string, data: Partial<CreatePatientData>): Promise<Patient> => {
     return apiPatch<Patient>(`/patients/${id}`, data);
+  },
+
+  delete: (id: string): Promise<void> => {
+    return apiDelete<void>(`/patients/${id}`);
+  },
+
+  createDetail: (patientId: string, data: CreatePatientDetailData): Promise<PatientDetail> => {
+    return apiPost<PatientDetail>(`/patients/${patientId}/detail`, data);
+  },
+
+  updateDetail: (
+    patientId: string,
+    data: Partial<CreatePatientDetailData>,
+  ): Promise<PatientDetail> => {
+    return apiPatch<PatientDetail>(`/patients/${patientId}/detail`, data);
   },
 };

--- a/apps/frontend/src/types/patient.ts
+++ b/apps/frontend/src/types/patient.ts
@@ -47,3 +47,13 @@ export interface FindPatientsParams {
   sortBy?: string;
   sortOrder?: 'asc' | 'desc';
 }
+
+export interface CreatePatientDetailData {
+  ssn?: string;
+  medicalHistory?: string;
+  allergies?: string;
+  insuranceType?: string;
+  insuranceNumber?: string;
+  insuranceCompany?: string;
+  notes?: string;
+}


### PR DESCRIPTION
## Summary
- Add `deletePatient`, `createPatientDetail`, `updatePatientDetail` to patient API service
- Add `useUpdatePatient`, `useDeletePatient`, `useCreatePatientDetail`, `useUpdatePatientDetail` React Query mutation hooks
- Add `CreatePatientDetailData` type definition
- All mutations include proper cache invalidation for related queries
- Export new hooks from hooks barrel file

Note: Admission write APIs (`create`, `transfer`, `discharge`, `getTransfers`) and their hooks were already implemented.

Closes #208

## Test Plan
- [ ] Verify TypeScript compilation passes
- [ ] Verify new API methods match backend endpoints
- [ ] Verify cache invalidation works on mutations