### PR TITLE
feat(backend): add audit logging for pii access in data masking service

### DIFF
--- a/apps/backend/src/modules/admin/admin.module.ts
+++ b/apps/backend/src/modules/admin/admin.module.ts
@@ -7,6 +7,7 @@ import { AuditService } from './audit.service';
 import { AuditQueryService } from './audit-query.service';
 import { AuditController } from './audit.controller';
 import { AuditInterceptor } from './interceptors';
+import { PiiAccessListener } from './pii-access.listener';
 import { UserAdminRepository } from './user-admin.repository';
 import { UserAdminService } from './user-admin.service';
 import { UserAdminController } from './user-admin.controller';
@@ -21,6 +22,7 @@ import { RoleController } from './role.controller';
     AuditRepository,
     AuditService,
     AuditQueryService,
+    PiiAccessListener,
     {
       provide: APP_INTERCEPTOR,
       useClass: AuditInterceptor,

--- a/apps/backend/src/modules/admin/pii-access.listener.ts
+++ b/apps/backend/src/modules/admin/pii-access.listener.ts
@@ -1,0 +1,35 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { AuditAction } from '@prisma/client';
+import { AuditRepository } from './audit.repository';
+import type { PiiAccessEvent } from '../patient/patient.service';
+
+@Injectable()
+export class PiiAccessListener {
+  private readonly logger = new Logger(PiiAccessListener.name);
+
+  constructor(private readonly auditRepository: AuditRepository) {}
+
+  @OnEvent('pii.accessed')
+  async handlePiiAccess(event: PiiAccessEvent): Promise<void> {
+    try {
+      await this.auditRepository.createAccessLog({
+        userId: 'system',
+        username: 'system',
+        userRole: event.role,
+        ipAddress: '0.0.0.0',
+        resourceType: 'patient_pii',
+        resourceId: event.patientId,
+        action: AuditAction.READ,
+        patientId: event.patientId,
+        accessedFields: event.accessedFields,
+      });
+
+      this.logger.log(
+        `PII access logged: role=${event.role} patient=${event.patientId} fields=${event.accessedFields.join(',')}`,
+      );
+    } catch (error) {
+      this.logger.error('Failed to log PII access', error);
+    }
+  }
+}

--- a/apps/backend/src/modules/integration/legacy-patient/services/patient-sync.service.ts
+++ b/apps/backend/src/modules/integration/legacy-patient/services/patient-sync.service.ts
@@ -100,7 +100,9 @@ export class PatientSyncService {
       name: patient.name,
       birthDate: patient.birthDate,
       gender: patient.gender,
-      ssn: this.nullToUndefined(patient.ssn ? this.dataMaskingService.maskSsn(patient.ssn) : null),
+      ssn: this.nullToUndefined(
+        patient.ssn ? this.dataMaskingService.maskSsn(patient.ssn).value : null,
+      ),
       phone: this.nullToUndefined(
         patient.phone ? this.dataMaskingService.maskPhone(patient.phone) : null,
       ),
@@ -111,7 +113,7 @@ export class PatientSyncService {
       insuranceType: patient.insuranceType,
       insuranceNumber: this.nullToUndefined(
         patient.insuranceNumber
-          ? this.dataMaskingService.maskInsuranceNumber(patient.insuranceNumber)
+          ? this.dataMaskingService.maskInsuranceNumber(patient.insuranceNumber).value
           : null,
       ),
     };

--- a/apps/backend/src/modules/patient/__tests__/data-masking.service.spec.ts
+++ b/apps/backend/src/modules/patient/__tests__/data-masking.service.spec.ts
@@ -34,47 +34,72 @@ describe('DataMaskingService', () => {
     });
   });
 
+  describe('maskPhone (role-based)', () => {
+    it('should return unmasked phone for ADMIN role', () => {
+      const result = service.maskPhone('01012345678', 'ADMIN');
+      expect(result).toBe('01012345678');
+    });
+
+    it('should return unmasked phone for DOCTOR role', () => {
+      const result = service.maskPhone('01012345678', 'DOCTOR');
+      expect(result).toBe('01012345678');
+    });
+
+    it('should mask phone for NURSE role', () => {
+      const result = service.maskPhone('01012345678', 'NURSE');
+      expect(result).toBe('010-****-5678');
+    });
+  });
+
   describe('maskSsn', () => {
     it('should mask SSN with 13 digits', () => {
       const result = service.maskSsn('9001011234567');
-      expect(result).toBe('900101-1******');
+      expect(result.value).toBe('900101-1******');
+      expect(result.unmasked).toBe(false);
     });
 
     it('should mask SSN with dash', () => {
       const result = service.maskSsn('900101-1234567');
-      expect(result).toBe('900101-1******');
+      expect(result.value).toBe('900101-1******');
+      expect(result.unmasked).toBe(false);
     });
 
-    it('should return full SSN for ADMIN role', () => {
+    it('should return full SSN for ADMIN role with unmasked flag', () => {
       const result = service.maskSsn('900101-1234567', 'ADMIN');
-      expect(result).toBe('900101-1234567');
+      expect(result.value).toBe('900101-1234567');
+      expect(result.unmasked).toBe(true);
     });
 
-    it('should return null for null input', () => {
+    it('should return null value for null input', () => {
       const result = service.maskSsn(null);
-      expect(result).toBeNull();
+      expect(result.value).toBeNull();
+      expect(result.unmasked).toBe(false);
     });
   });
 
   describe('maskInsuranceNumber', () => {
     it('should mask insurance number showing last 4 digits', () => {
       const result = service.maskInsuranceNumber('123456789012');
-      expect(result).toBe('********9012');
+      expect(result.value).toBe('********9012');
+      expect(result.unmasked).toBe(false);
     });
 
-    it('should return full number for ADMIN role', () => {
+    it('should return full number for ADMIN role with unmasked flag', () => {
       const result = service.maskInsuranceNumber('123456789012', 'ADMIN');
-      expect(result).toBe('123456789012');
+      expect(result.value).toBe('123456789012');
+      expect(result.unmasked).toBe(true);
     });
 
     it('should mask short numbers completely', () => {
       const result = service.maskInsuranceNumber('1234');
-      expect(result).toBe('****');
+      expect(result.value).toBe('****');
+      expect(result.unmasked).toBe(false);
     });
 
-    it('should return null for null input', () => {
+    it('should return null value for null input', () => {
       const result = service.maskInsuranceNumber(null);
-      expect(result).toBeNull();
+      expect(result.value).toBeNull();
+      expect(result.unmasked).toBe(false);
     });
   });
 

--- a/apps/backend/src/modules/patient/__tests__/patient.service.spec.ts
+++ b/apps/backend/src/modules/patient/__tests__/patient.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException, ConflictException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PatientService } from '../patient.service';
 import { PatientRepository } from '../patient.repository';
 import { PatientNumberGenerator } from '../patient-number.generator';
@@ -15,6 +16,7 @@ describe('PatientService', () => {
   let repository: jest.Mocked<PatientRepository>;
   let patientNumberGenerator: jest.Mocked<PatientNumberGenerator>;
   let dataMaskingService: DataMaskingService;
+  let eventEmitter: jest.Mocked<EventEmitter2>;
 
   const mockRepository = {
     create: jest.fn(),
@@ -35,12 +37,17 @@ describe('PatientService', () => {
     parsePatientNumber: jest.fn(),
   };
 
+  const mockEventEmitter = {
+    emit: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         PatientService,
         { provide: PatientRepository, useValue: mockRepository },
         { provide: PatientNumberGenerator, useValue: mockPatientNumberGenerator },
+        { provide: EventEmitter2, useValue: mockEventEmitter },
         DataMaskingService,
       ],
     }).compile();
@@ -49,6 +56,7 @@ describe('PatientService', () => {
     repository = module.get(PatientRepository);
     patientNumberGenerator = module.get(PatientNumberGenerator);
     dataMaskingService = module.get<DataMaskingService>(DataMaskingService);
+    eventEmitter = module.get(EventEmitter2);
 
     jest.clearAllMocks();
   });

--- a/apps/backend/src/modules/patient/data-masking.service.ts
+++ b/apps/backend/src/modules/patient/data-masking.service.ts
@@ -4,8 +4,12 @@ export type UserRole = 'ADMIN' | 'DOCTOR' | 'NURSE' | 'STAFF';
 
 @Injectable()
 export class DataMaskingService {
-  maskPhone(phone: string | null): string | null {
+  maskPhone(phone: string | null, role?: UserRole): string | null {
     if (!phone) return null;
+
+    if (role === 'ADMIN' || role === 'DOCTOR') {
+      return phone;
+    }
 
     const digits = phone.replace(/\D/g, '');
     if (digits.length < 7) return phone;
@@ -23,35 +27,38 @@ export class DataMaskingService {
     return `${visibleStart}-${maskedMiddle}-${visibleEnd}`;
   }
 
-  maskSsn(ssn: string | null, role?: UserRole): string | null {
-    if (!ssn) return null;
+  maskSsn(ssn: string | null, role?: UserRole): { value: string | null; unmasked: boolean } {
+    if (!ssn) return { value: null, unmasked: false };
 
     if (role === 'ADMIN') {
-      return ssn;
+      return { value: ssn, unmasked: true };
     }
 
     const digits = ssn.replace(/\D/g, '');
     if (digits.length === 13) {
-      return `${digits.slice(0, 6)}-${digits.charAt(6)}******`;
+      return { value: `${digits.slice(0, 6)}-${digits.charAt(6)}******`, unmasked: false };
     }
 
-    return ssn.replace(/(\d{6})-?(\d)(\d{6})/, '$1-$2******');
+    return { value: ssn.replace(/(\d{6})-?(\d)(\d{6})/, '$1-$2******'), unmasked: false };
   }
 
-  maskInsuranceNumber(insuranceNumber: string | null, role?: UserRole): string | null {
-    if (!insuranceNumber) return null;
+  maskInsuranceNumber(
+    insuranceNumber: string | null,
+    role?: UserRole,
+  ): { value: string | null; unmasked: boolean } {
+    if (!insuranceNumber) return { value: null, unmasked: false };
 
     if (role === 'ADMIN') {
-      return insuranceNumber;
+      return { value: insuranceNumber, unmasked: true };
     }
 
     if (insuranceNumber.length <= 4) {
-      return '*'.repeat(insuranceNumber.length);
+      return { value: '*'.repeat(insuranceNumber.length), unmasked: false };
     }
 
     const visibleEnd = insuranceNumber.slice(-4);
     const maskedPart = '*'.repeat(insuranceNumber.length - 4);
-    return maskedPart + visibleEnd;
+    return { value: maskedPart + visibleEnd, unmasked: false };
   }
 
   maskAddress(address: string | null): string | null {

--- a/apps/backend/src/modules/patient/patient.service.ts
+++ b/apps/backend/src/modules/patient/patient.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, NotFoundException, ConflictException } from '@nestjs/common';
+import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Patient, PatientDetail } from '@prisma/client';
 import { PatientRepository, PatientWithDetail } from './patient.repository';
 import { PatientNumberGenerator } from './patient-number.generator';
@@ -14,12 +15,21 @@ import {
   PaginatedPatientsResponseDto,
 } from './dto';
 
+export interface PiiAccessEvent {
+  patientId: string;
+  accessedFields: string[];
+  role: UserRole;
+}
+
 @Injectable()
 export class PatientService {
+  private readonly logger = new Logger(PatientService.name);
+
   constructor(
     private readonly repository: PatientRepository,
     private readonly patientNumberGenerator: PatientNumberGenerator,
     private readonly dataMaskingService: DataMaskingService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async create(dto: CreatePatientDto): Promise<PatientResponseDto> {
@@ -150,7 +160,7 @@ export class PatientService {
       notes: dto.notes,
     });
 
-    return this.toDetailResponseDto(detail);
+    return this.toDetailResponseDto(detail, patientId);
   }
 
   async updateDetail(
@@ -174,7 +184,7 @@ export class PatientService {
       notes: dto.notes,
     });
 
-    return this.toDetailResponseDto(detail);
+    return this.toDetailResponseDto(detail, patientId);
   }
 
   private toResponseDto(patient: Patient | PatientWithDetail, role?: UserRole): PatientResponseDto {
@@ -185,10 +195,10 @@ export class PatientService {
       birthDate: patient.birthDate,
       gender: patient.gender,
       bloodType: patient.bloodType,
-      phone: this.dataMaskingService.maskPhone(patient.phone),
+      phone: this.dataMaskingService.maskPhone(patient.phone, role),
       address: this.dataMaskingService.maskAddress(patient.address),
       emergencyContactName: patient.emergencyContactName,
-      emergencyContactPhone: this.dataMaskingService.maskPhone(patient.emergencyContactPhone),
+      emergencyContactPhone: this.dataMaskingService.maskPhone(patient.emergencyContactPhone, role),
       emergencyContactRelation: patient.emergencyContactRelation,
       legacyPatientId: patient.legacyPatientId,
       createdAt: patient.createdAt,
@@ -196,29 +206,50 @@ export class PatientService {
     };
 
     if ('detail' in patient && patient.detail) {
-      dto.detail = this.toDetailResponseDto(patient.detail, role);
+      dto.detail = this.toDetailResponseDto(patient.detail, patient.id, role);
     }
 
     return dto;
   }
 
-  private toDetailResponseDto(detail: PatientDetail, role?: UserRole): PatientDetailResponseDto {
+  private toDetailResponseDto(
+    detail: PatientDetail,
+    patientId: string,
+    role?: UserRole,
+  ): PatientDetailResponseDto {
+    const unmaskedFields: string[] = [];
+
+    const ssnResult = detail.ssnEncrypted
+      ? this.dataMaskingService.maskSsn(this.decryptData(detail.ssnEncrypted), role)
+      : { value: null, unmasked: false };
+
+    const insuranceResult = detail.insuranceNumberEncrypted
+      ? this.dataMaskingService.maskInsuranceNumber(
+          this.decryptData(detail.insuranceNumberEncrypted),
+          role,
+        )
+      : { value: null, unmasked: false };
+
+    if (ssnResult.unmasked) unmaskedFields.push('ssn');
+    if (insuranceResult.unmasked) unmaskedFields.push('insuranceNumber');
+
+    if (unmaskedFields.length > 0 && role) {
+      this.eventEmitter.emit('pii.accessed', {
+        patientId,
+        accessedFields: unmaskedFields,
+        role,
+      } as PiiAccessEvent);
+    }
+
     return {
       id: detail.id,
-      ssn: detail.ssnEncrypted
-        ? this.dataMaskingService.maskSsn(this.decryptData(detail.ssnEncrypted), role)
-        : null,
+      ssn: ssnResult.value,
       medicalHistory: detail.medicalHistoryEncrypted
         ? this.decryptData(detail.medicalHistoryEncrypted)
         : null,
       allergies: detail.allergiesEncrypted ? this.decryptData(detail.allergiesEncrypted) : null,
       insuranceType: detail.insuranceType,
-      insuranceNumber: detail.insuranceNumberEncrypted
-        ? this.dataMaskingService.maskInsuranceNumber(
-            this.decryptData(detail.insuranceNumberEncrypted),
-            role,
-          )
-        : null,
+      insuranceNumber: insuranceResult.value,
       insuranceCompany: detail.insuranceCompany,
       notes: detail.notes,
     };


### PR DESCRIPTION
## Summary
- Track unmasked SSN and insurance number access with `{value, unmasked}` return type from masking methods
- Emit `pii.accessed` event via EventEmitter2 when ADMIN bypasses PII masking
- Add `PiiAccessListener` in admin module to log PII access to `AccessLog` table
- Add role-based phone masking (ADMIN/DOCTOR see full number, NURSE/STAFF see masked)
- Update unit tests for new return types and EventEmitter2 dependency
- Update patient-sync service for new masking API

Closes #210

## Test Plan
- [ ] Verify ADMIN access to patient detail logs PII access in AccessLog table
- [ ] Verify non-ADMIN users still see masked SSN and insurance numbers
- [ ] Verify phone masking follows role-based rules
- [ ] Verify unit tests pass with updated assertions