### PR TITLE
fix(infra): fix production docker compose security issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Dependencies
+node_modules
+.pnpm-store
+
+# Build outputs
+dist
+.next
+out
+
+# Environment files
+.env
+.env.*
+!.env.example
+
+# Version control
+.git
+.gitignore
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test and coverage
+coverage
+.nyc_output
+cypress/videos
+cypress/screenshots
+
+# Documentation
+docs
+*.md
+!README.md
+
+# CI/CD
+.github
+.claude
+
+# Credentials and secrets
+*.pem
+*.key
+*.p12
+credentials
+secrets

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # Production Docker Compose Configuration
 # This file is for reference - use Kubernetes or similar orchestration in production
 
@@ -9,8 +7,6 @@ services:
     image: postgres:16-alpine
     container_name: hospital-erp-db-prod
     restart: always
-    ports:
-      - '5432:5432'
     environment:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -25,6 +21,11 @@ services:
       retries: 5
     networks:
       - hospital-network
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
     deploy:
       resources:
         limits:
@@ -39,18 +40,21 @@ services:
     image: redis:7-alpine
     container_name: hospital-erp-redis-prod
     restart: always
-    ports:
-      - '6379:6379'
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
     healthcheck:
-      test: ['CMD', 'redis-cli', '-a', '${REDIS_PASSWORD}', 'ping']
+      test: ['CMD-SHELL', 'REDISCLI_AUTH=${REDIS_PASSWORD} redis-cli ping']
       interval: 10s
       timeout: 5s
       retries: 5
     networks:
       - hospital-network
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
     deploy:
       resources:
         limits:
@@ -72,7 +76,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: 3000
-      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}?connection_limit=20&pool_timeout=30
+      DATABASE_URL: postgresql://${DB_USER}:${DB_PASSWORD}@postgres:5432/${DB_NAME}?sslmode=require&connection_limit=20&pool_timeout=30
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
       JWT_ACCESS_SECRET: ${JWT_ACCESS_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}
@@ -86,6 +90,11 @@ services:
         condition: service_healthy
     networks:
       - hospital-network
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
     deploy:
       resources:
         limits:
@@ -116,6 +125,11 @@ services:
       - backend
     networks:
       - hospital-network
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
     deploy:
       resources:
         limits:
@@ -128,7 +142,7 @@ services:
 
   # Nginx Reverse Proxy (optional)
   nginx:
-    image: nginx:alpine
+    image: nginx:1.27-alpine
     container_name: hospital-erp-nginx
     restart: always
     ports:
@@ -142,6 +156,11 @@ services:
       - backend
     networks:
       - hospital-network
+    logging:
+      driver: json-file
+      options:
+        max-size: '10m'
+        max-file: '5'
     profiles:
       - with-nginx
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL 16
   postgres:


### PR DESCRIPTION
## Summary
- Remove exposed ports for PostgreSQL (5432) and Redis (6379) in production compose — services communicate via internal Docker network only
- Add `sslmode=require` to `DATABASE_URL` template for encrypted database connections
- Use `REDISCLI_AUTH` env var instead of `-a` flag for Redis health check to prevent credential leakage in process listing
- Pin Nginx image to `1.27-alpine` instead of unpinned `nginx:alpine`
- Add `json-file` log driver with rotation (10MB, 5 files) to all services to prevent disk exhaustion
- Remove deprecated `version: '3.8'` field from both compose files
- Add root `.dockerignore` to prevent sensitive files (.env, .git, credentials) from entering build context

Closes #211

## Test Plan
- [ ] Verify `docker compose -f docker-compose.prod.yml config` validates without errors
- [ ] Verify PostgreSQL and Redis are not accessible from host network
- [ ] Verify backend can still connect to PostgreSQL and Redis via internal network
- [ ] Verify log rotation configuration is applied