### PR TITLE
fix(k8s): fix production affinity label mismatch

### DIFF
--- a/k8s/overlays/production/patches/production-affinity.yaml
+++ b/k8s/overlays/production/patches/production-affinity.yaml
@@ -10,7 +10,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
-                  - key: app
+                  - key: app.kubernetes.io/name
                     operator: In
                     values:
                       - backend
@@ -28,7 +28,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - labelSelector:
                 matchExpressions:
-                  - key: app
+                  - key: app.kubernetes.io/name
                     operator: In
                     values:
                       - frontend


### PR DESCRIPTION
## Summary
- Fix affinity label selector from `app` to `app.kubernetes.io/name` to match the actual labels used in base deployment manifests
- Applies to both backend and frontend affinity rules
- Ensures pod anti-affinity actually distributes pods across different nodes

Closes #212

## Test Plan
- [ ] Verify `kubectl get pods -o wide` shows pods distributed across different nodes
- [ ] Run `kubectl diff` to confirm patch applies correctly