### PR TITLE
feat(k8s): add pgbouncer deployment and database tls configuration

### DIFF
--- a/k8s/base/database/kustomization.yaml
+++ b/k8s/base/database/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - pgbouncer-configmap.yaml
+  - pgbouncer-deployment.yaml
+  - pgbouncer-service.yaml
   - pgbouncer-hpa.yaml

--- a/k8s/base/database/pgbouncer-configmap.yaml
+++ b/k8s/base/database/pgbouncer-configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgbouncer-config
+  labels:
+    app.kubernetes.io/name: pgbouncer
+    app.kubernetes.io/component: database
+data:
+  pgbouncer.ini: |
+    [databases]
+    hospital_erp = host=postgres port=5432 dbname=hospital_erp
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = 6432
+    auth_type = md5
+    auth_file = /etc/pgbouncer/userlist.txt
+    pool_mode = transaction
+    default_pool_size = 20
+    min_pool_size = 5
+    max_client_conn = 200
+    max_db_connections = 50
+    server_tls_sslmode = require
+    log_connections = 1
+    log_disconnections = 1
+    log_pooler_errors = 1
+    stats_period = 60
+    server_idle_timeout = 600
+    server_lifetime = 3600
+    client_idle_timeout = 0
+    query_wait_timeout = 120

--- a/k8s/base/database/pgbouncer-deployment.yaml
+++ b/k8s/base/database/pgbouncer-deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgbouncer
+  labels:
+    app.kubernetes.io/name: pgbouncer
+    app.kubernetes.io/component: database
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pgbouncer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pgbouncer
+        app.kubernetes.io/component: database
+    spec:
+      containers:
+        - name: pgbouncer
+          image: bitnami/pgbouncer:1.23.1
+          ports:
+            - containerPort: 6432
+              protocol: TCP
+          env:
+            - name: POSTGRESQL_HOST
+              value: postgres
+            - name: POSTGRESQL_PORT
+              value: '5432'
+            - name: POSTGRESQL_DATABASE
+              value: hospital_erp
+            - name: POSTGRESQL_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: database-credentials
+                  key: username
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: database-credentials
+                  key: password
+            - name: PGBOUNCER_POOL_MODE
+              value: transaction
+            - name: PGBOUNCER_DEFAULT_POOL_SIZE
+              value: '20'
+            - name: PGBOUNCER_MAX_CLIENT_CONN
+              value: '200'
+            - name: PGBOUNCER_MAX_DB_CONNECTIONS
+              value: '50'
+            - name: PGBOUNCER_SERVER_TLS_SSLMODE
+              value: require
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          volumeMounts:
+            - name: pgbouncer-config
+              mountPath: /bitnami/pgbouncer/conf
+              readOnly: true
+      volumes:
+        - name: pgbouncer-config
+          configMap:
+            name: pgbouncer-config

--- a/k8s/base/database/pgbouncer-service.yaml
+++ b/k8s/base/database/pgbouncer-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgbouncer
+  labels:
+    app.kubernetes.io/name: pgbouncer
+    app.kubernetes.io/component: database
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: pgbouncer
+  ports:
+    - name: pgbouncer
+      port: 6432
+      targetPort: 6432
+      protocol: TCP

--- a/k8s/overlays/production/external-secrets/database-external-secret.yaml
+++ b/k8s/overlays/production/external-secrets/database-external-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: database-credentials
+  labels:
+    app.kubernetes.io/name: database-credentials
+    app.kubernetes.io/component: database
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: database-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: hospital-erp/database
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: hospital-erp/database
+        property: password
+    - secretKey: host
+      remoteRef:
+        key: hospital-erp/database
+        property: host


### PR DESCRIPTION
## Summary
- Add PgBouncer Deployment manifest (`bitnami/pgbouncer:1.23.1`) with transaction pool mode
- Add PgBouncer ConfigMap with pool settings, TLS, and logging configuration
- Add PgBouncer ClusterIP Service on port 6432 for backend connectivity
- Update database kustomization to include all PgBouncer resources
- Add ExternalSecret manifest for database credentials via AWS Secrets Manager
- Configure `server_tls_sslmode=require` for encrypted PostgreSQL connections

Closes #213

## Test Plan
- [ ] Verify PgBouncer pods start and reach Ready state
- [ ] Verify backend can connect to PostgreSQL via PgBouncer on port 6432
- [ ] Verify connection pooling reduces database connection count
- [ ] Verify TLS is enforced on database connections