### PR TITLE
feat(auth): enhance rate limiting with redis storage and endpoint-specific limits

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { EventEmitterModule } from '@nestjs/event-emitter';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { ThrottlerModule, ThrottlerGuard, ThrottlerStorage } from '@nestjs/throttler';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ThrottlerRedisStorageService } from './common/throttler';
 import { PrismaModule } from './prisma/prisma.module';
 import { RedisModule } from './redis';
 import { MetricsModule, MetricsInterceptor } from './metrics';
@@ -26,23 +27,26 @@ import { appConfig, databaseConfig, redisConfig, jwtConfig, validate } from './c
       validate,
     }),
     EventEmitterModule.forRoot(),
-    ThrottlerModule.forRoot([
-      {
-        name: 'short',
-        ttl: 1000,
-        limit: 3,
-      },
-      {
-        name: 'medium',
-        ttl: 10000,
-        limit: 20,
-      },
-      {
-        name: 'long',
-        ttl: 60000,
-        limit: 100,
-      },
-    ]),
+    ThrottlerModule.forRoot({
+      throttlers: [
+        {
+          name: 'short',
+          ttl: 1000,
+          limit: 3,
+        },
+        {
+          name: 'medium',
+          ttl: 10000,
+          limit: 20,
+        },
+        {
+          name: 'long',
+          ttl: 60000,
+          limit: 100,
+        },
+      ],
+      errorMessage: 'Too many requests. Please try again later.',
+    }),
     RedisModule,
     PrismaModule,
     MetricsModule,
@@ -58,6 +62,10 @@ import { appConfig, databaseConfig, redisConfig, jwtConfig, validate } from './c
   ],
   controllers: [],
   providers: [
+    {
+      provide: ThrottlerStorage,
+      useClass: ThrottlerRedisStorageService,
+    },
     {
       provide: APP_GUARD,
       useClass: ThrottlerGuard,

--- a/apps/backend/src/common/index.ts
+++ b/apps/backend/src/common/index.ts
@@ -3,3 +3,4 @@ export * from './filters';
 export * from './guards';
 export * from './interceptors';
 export * from './pipes';
+export * from './throttler';

--- a/apps/backend/src/common/throttler/index.ts
+++ b/apps/backend/src/common/throttler/index.ts
@@ -1,0 +1,1 @@
+export * from './throttler-redis-storage.service';

--- a/apps/backend/src/common/throttler/throttler-redis-storage.service.ts
+++ b/apps/backend/src/common/throttler/throttler-redis-storage.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+import Redis from 'ioredis';
+import { ThrottlerStorage } from '@nestjs/throttler';
+
+interface StorageRecord {
+  totalHits: number;
+  timeToExpire: number;
+  isBlocked: boolean;
+  timeToBlockExpire: number;
+}
+
+@Injectable()
+export class ThrottlerRedisStorageService implements ThrottlerStorage, OnModuleInit {
+  private scriptSha: string;
+
+  constructor(@InjectRedis() private readonly redis: Redis) {}
+
+  /**
+   * Lua script for atomic increment with TTL and block duration.
+   * Returns [totalHits, timeToExpire, isBlocked, timeToBlockExpire].
+   */
+  private readonly luaScript = `
+    local key = KEYS[1]
+    local blockKey = KEYS[2]
+    local ttl = tonumber(ARGV[1])
+    local limit = tonumber(ARGV[2])
+    local blockDuration = tonumber(ARGV[3])
+
+    -- Check if blocked
+    local blockTTL = redis.call('PTTL', blockKey)
+    if blockTTL > 0 then
+      local hits = tonumber(redis.call('GET', key) or 0)
+      return {hits, 0, 1, blockTTL}
+    end
+
+    -- Increment hits
+    local hits = redis.call('INCR', key)
+    if hits == 1 then
+      redis.call('PEXPIRE', key, ttl)
+    end
+
+    local pttl = redis.call('PTTL', key)
+    if pttl < 0 then
+      pttl = ttl
+    end
+
+    -- Block if over limit
+    if hits > limit and blockDuration > 0 then
+      redis.call('SET', blockKey, 1, 'PX', blockDuration)
+      return {hits, pttl, 1, blockDuration}
+    end
+
+    return {hits, pttl, 0, 0}
+  `;
+
+  async onModuleInit() {
+    this.scriptSha = (await this.redis.script('LOAD', this.luaScript)) as string;
+  }
+
+  async increment(
+    key: string,
+    ttl: number,
+    limit: number,
+    blockDuration: number,
+    _throttlerName: string,
+  ): Promise<StorageRecord> {
+    const blockKey = `${key}:blocked`;
+    const results = (await this.redis.evalsha(
+      this.scriptSha,
+      2,
+      key,
+      blockKey,
+      ttl,
+      limit,
+      blockDuration,
+    )) as number[];
+
+    return {
+      totalHits: results[0],
+      timeToExpire: results[1],
+      isBlocked: results[2] === 1,
+      timeToBlockExpire: results[3],
+    };
+  }
+}

--- a/apps/backend/src/modules/auth/auth.controller.ts
+++ b/apps/backend/src/modules/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
   Param,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiParam } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
 import { Request } from 'express';
 import { User } from '@prisma/client';
 import { AuthService, SessionService } from './services';
@@ -41,8 +42,14 @@ export class AuthController {
   @ApiResponse({ status: 200, description: 'Login successful', type: LoginResponseDto })
   @ApiResponse({ status: 401, description: 'Invalid credentials' })
   @ApiResponse({ status: 423, description: 'Account locked' })
+  @ApiResponse({ status: 429, description: 'Too many login attempts' })
   @Public()
   @UseGuards(LocalAuthGuard)
+  @Throttle({
+    short: { ttl: 60000, limit: 10 },
+    medium: { ttl: 60000, limit: 10 },
+    long: { ttl: 60000, limit: 10 },
+  })
   @Post('login')
   @HttpCode(HttpStatus.OK)
   async login(@Req() req: Request, @Body() loginDto: LoginDto): Promise<LoginResponseDto> {
@@ -56,7 +63,13 @@ export class AuthController {
   @ApiOperation({ summary: 'Refresh access token' })
   @ApiResponse({ status: 200, description: 'Tokens refreshed', type: TokenResponseDto })
   @ApiResponse({ status: 401, description: 'Invalid refresh token' })
+  @ApiResponse({ status: 429, description: 'Too many refresh attempts' })
   @Public()
+  @Throttle({
+    short: { ttl: 60000, limit: 20 },
+    medium: { ttl: 60000, limit: 20 },
+    long: { ttl: 60000, limit: 20 },
+  })
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
   async refresh(@Body() refreshTokenDto: RefreshTokenDto): Promise<TokenResponseDto> {

--- a/apps/backend/src/modules/health/health.controller.ts
+++ b/apps/backend/src/modules/health/health.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
 import { HealthService, HealthCheckResult } from './health.service';
 
 @ApiTags('health')
+@SkipThrottle()
 @Controller('health')
 export class HealthController {
   constructor(private readonly healthService: HealthService) {}


### PR DESCRIPTION
## Summary
- Add `@SkipThrottle()` to health controller to prevent Kubernetes probe rate limit failures
- Add stricter rate limits for auth endpoints: login (10 req/min), refresh (20 req/min)
- Implement Redis-based `ThrottlerRedisStorageService` for multi-replica consistency using Lua scripts
- Switch ThrottlerModule to object config form with custom 429 error message

## Test Plan
- [ ] Health check endpoints (`/health`, `/health/live`, `/health/ready`) are not rate limited
- [ ] Login endpoint returns 429 after 10 attempts per minute
- [ ] Refresh endpoint returns 429 after 20 attempts per minute
- [ ] Rate limit state is shared across replicas via Redis
- [ ] General API endpoints still follow global limits (3/1s, 20/10s, 100/60s)

Closes #214