### PR TITLE
fix(auth): fix post-login redirect and preserve deep link urls

### DIFF
--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -24,13 +24,18 @@ export function middleware(request: NextRequest) {
   if (!authStorage && pathname !== '/login') {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
+    if (pathname !== '/') {
+      url.searchParams.set('redirect', pathname);
+    }
     return NextResponse.redirect(url);
   }
 
-  // If has auth storage and on login page, redirect to dashboard
+  // If has auth storage and on login page, redirect to patients
   if (authStorage && pathname === '/login') {
     const url = request.nextUrl.clone();
-    url.pathname = '/';
+    const redirect = request.nextUrl.searchParams.get('redirect');
+    url.pathname = redirect || '/patients';
+    url.searchParams.delete('redirect');
     return NextResponse.redirect(url);
   }
 

--- a/apps/frontend/src/app/(auth)/login/page.tsx
+++ b/apps/frontend/src/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuthStore } from '@/stores';
@@ -20,6 +20,7 @@ import { Button } from '@/components/ui/button';
 
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { login, isLoading, error, clearError } = useAuthStore();
 
   const form = useForm<LoginFormData>({
@@ -34,7 +35,8 @@ export default function LoginPage() {
     clearError();
     try {
       await login(data);
-      router.push('/');
+      const redirectTo = searchParams.get('redirect') || '/patients';
+      router.push(redirectTo);
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.message.includes('locked')) {

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,22 +1,5 @@
-import { Button } from '@/components/ui/button';
+import { redirect } from 'next/navigation';
 
 export default function Home() {
-  return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-8 p-8">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold tracking-tight">Hospital ERP System</h1>
-        <p className="mt-4 text-lg text-muted-foreground">
-          Hospital Inpatient Management ERP System
-        </p>
-      </div>
-      <div className="flex gap-4">
-        <Button asChild>
-          <a href="/login">Login</a>
-        </Button>
-        <Button variant="outline" asChild>
-          <a href="/dashboard">Dashboard</a>
-        </Button>
-      </div>
-    </div>
-  );
+  redirect('/patients');
 }

--- a/apps/frontend/src/components/auth/auth-guard.tsx
+++ b/apps/frontend/src/components/auth/auth-guard.tsx
@@ -23,9 +23,10 @@ export function AuthGuard({ children }: AuthGuardProps) {
     const isPublicPath = PUBLIC_PATHS.includes(pathname);
 
     if (!isAuthenticated && !isPublicPath) {
-      router.replace('/login');
+      const redirectParam = pathname !== '/' ? `?redirect=${encodeURIComponent(pathname)}` : '';
+      router.replace(`/login${redirectParam}`);
     } else if (isAuthenticated && isPublicPath) {
-      router.replace('/');
+      router.replace('/patients');
     }
   }, [isAuthenticated, isHydrated, pathname, router]);
 


### PR DESCRIPTION
## Summary
- Replace useless root landing page with server-side redirect to `/patients`
- Store original URL as `?redirect=` query param when redirecting unauthenticated users to login
- After login, redirect to stored URL (or `/patients` as default) instead of `/`
- Update both middleware (server-side) and AuthGuard (client-side) consistently

## Test Plan
- [ ] Visiting `/` while unauthenticated redirects to `/login`
- [ ] Visiting `/rooms` while unauthenticated redirects to `/login?redirect=%2Frooms`
- [ ] After login from `/login?redirect=%2Frooms`, user lands on `/rooms`
- [ ] After normal login (no redirect param), user lands on `/patients`
- [ ] Authenticated user visiting `/login` is redirected to `/patients`

Closes #215