### PR TITLE
docs(api): add missing swagger tags and integration controller documentation

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -37,14 +37,19 @@ async function bootstrap() {
       .setDescription('Inpatient Management ERP System API Documentation')
       .setVersion('1.0')
       .addBearerAuth()
+      .addTag('health', 'Health check and probe endpoints')
       .addTag('auth', 'Authentication endpoints')
       .addTag('patients', 'Patient management')
       .addTag('rooms', 'Room and bed management')
       .addTag('admissions', 'Admission/discharge management')
       .addTag('vitals', 'Vital signs recording')
+      .addTag('medications', 'Medication management')
+      .addTag('nursing-notes', 'Nursing note management')
+      .addTag('daily-reports', 'Daily report management')
+      .addTag('intake-output', 'Intake and output tracking')
       .addTag('rounds', 'Rounding management')
-      .addTag('reports', 'Reporting endpoints')
       .addTag('admin', 'Admin functions')
+      .addTag('integration', 'Legacy system integration')
       .build();
 
     const document = SwaggerModule.createDocument(app, config);

--- a/apps/backend/src/modules/integration/legacy-patient/legacy-patient.controller.ts
+++ b/apps/backend/src/modules/integration/legacy-patient/legacy-patient.controller.ts
@@ -8,6 +8,14 @@ import {
   HttpStatus,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../../../common/guards';
 import { PermissionGuard } from '../../auth/guards';
 import { RequirePermission } from '../../auth/decorators';
@@ -16,18 +24,29 @@ import { PatientSyncService } from './services';
 import { LegacyPatientResponseDto, MedicalHistoryResponseDto } from './dto';
 import { PatientResponseDto } from '../../patient/dto';
 
+@ApiTags('integration')
+@ApiBearerAuth()
 @Controller('patients/legacy')
 @UseGuards(JwtAuthGuard, PermissionGuard)
 export class LegacyPatientController {
   constructor(private readonly patientSyncService: PatientSyncService) {}
 
   @Get('search')
+  @ApiOperation({ summary: 'Search patients in legacy system' })
+  @ApiQuery({ name: 'q', required: false, description: 'Search query string' })
+  @ApiResponse({
+    status: 200,
+    description: 'Matching legacy patients',
+    type: [LegacyPatientResponseDto],
+  })
   @RequirePermission(Permissions.PATIENT_READ)
   async searchLegacy(@Query('q') query: string): Promise<LegacyPatientResponseDto[]> {
     return this.patientSyncService.searchLegacy(query || '');
   }
 
   @Get('health')
+  @ApiOperation({ summary: 'Check legacy system connection status' })
+  @ApiResponse({ status: 200, description: 'Connection status' })
   @RequirePermission(Permissions.PATIENT_READ)
   async checkConnection(): Promise<{ connected: boolean }> {
     const connected = await this.patientSyncService.checkConnection();
@@ -35,18 +54,35 @@ export class LegacyPatientController {
   }
 
   @Get(':legacyId')
+  @ApiOperation({ summary: 'Find patient by legacy system ID' })
+  @ApiParam({ name: 'legacyId', description: 'Legacy system patient ID' })
+  @ApiResponse({ status: 200, description: 'Legacy patient data', type: LegacyPatientResponseDto })
   @RequirePermission(Permissions.PATIENT_READ)
   async findByLegacyId(@Param('legacyId') legacyId: string): Promise<LegacyPatientResponseDto> {
     return this.patientSyncService.findLegacyById(legacyId);
   }
 
   @Get(':legacyId/medical-history')
+  @ApiOperation({ summary: 'Get medical history from legacy system' })
+  @ApiParam({ name: 'legacyId', description: 'Legacy system patient ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medical history data',
+    type: MedicalHistoryResponseDto,
+  })
   @RequirePermission(Permissions.PATIENT_READ)
   async getMedicalHistory(@Param('legacyId') legacyId: string): Promise<MedicalHistoryResponseDto> {
     return this.patientSyncService.getMedicalHistory(legacyId);
   }
 
   @Post(':legacyId/import')
+  @ApiOperation({ summary: 'Import patient from legacy system' })
+  @ApiParam({ name: 'legacyId', description: 'Legacy system patient ID to import' })
+  @ApiResponse({
+    status: 201,
+    description: 'Patient imported successfully',
+    type: PatientResponseDto,
+  })
   @RequirePermission(Permissions.PATIENT_CREATE)
   @HttpCode(HttpStatus.CREATED)
   async importFromLegacy(@Param('legacyId') legacyId: string): Promise<PatientResponseDto> {


### PR DESCRIPTION
## Summary
- Add 6 missing Swagger tag declarations: health, medications, nursing-notes, daily-reports, intake-output, integration
- Remove unused `reports` tag (no controller uses it)
- Add full Swagger decorators to `LegacyPatientController`: `@ApiTags`, `@ApiBearerAuth`, `@ApiOperation`, `@ApiResponse`, `@ApiParam`, `@ApiQuery`

## Test Plan
- [ ] All tags in Swagger UI (`/api/docs`) have descriptions
- [ ] Integration endpoints appear under "integration" tag with lock icon
- [ ] No endpoints appear under "default" ungrouped tag

Closes #216