### PR TITLE
feat(admission): add admission update endpoint and patient history query api

### DIFF
--- a/apps/backend/src/modules/admission/admission.controller.ts
+++ b/apps/backend/src/modules/admission/admission.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards } from '@nestjs/common';
 import {
   ApiTags,
   ApiOperation,
@@ -16,6 +16,7 @@ import { Permissions } from '../auth/constants';
 import { AdmissionStatus } from '@prisma/client';
 import {
   CreateAdmissionDto,
+  UpdateAdmissionDto,
   TransferDto,
   DischargeDto,
   FindAdmissionsDto,
@@ -113,6 +114,21 @@ export class AdmissionController {
     @Query('status') status?: AdmissionStatus,
   ): Promise<AdmissionResponseDto[]> {
     return this.admissionService.findByFloor(floorId, status);
+  }
+
+  @ApiOperation({ summary: 'Update admission details' })
+  @ApiParam({ name: 'id', description: 'Admission ID', format: 'uuid' })
+  @ApiResponse({ status: 200, description: 'Admission updated', type: AdmissionResponseDto })
+  @ApiResponse({ status: 400, description: 'Admission is not active' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Admission not found' })
+  @RequirePermission(Permissions.ADMISSION_UPDATE)
+  @Patch(':id')
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateAdmissionDto,
+  ): Promise<AdmissionResponseDto> {
+    return this.admissionService.updateAdmission(id, dto);
   }
 
   @ApiOperation({ summary: 'Find admission by ID' })

--- a/apps/backend/src/modules/admission/admission.service.ts
+++ b/apps/backend/src/modules/admission/admission.service.ts
@@ -6,6 +6,7 @@ import { AdmissionNumberGenerator } from './admission-number.generator';
 import { BedService } from '../room/bed.service';
 import {
   CreateAdmissionDto,
+  UpdateAdmissionDto,
   TransferDto,
   DischargeDto,
   FindAdmissionsDto,
@@ -211,6 +212,30 @@ export class AdmissionService {
     });
 
     return this.toDischargeResponseDto(discharge);
+  }
+
+  async updateAdmission(id: string, dto: UpdateAdmissionDto): Promise<AdmissionResponseDto> {
+    const admission = await this.repository.findById(id);
+    if (!admission) {
+      throw new AdmissionNotFoundException(id);
+    }
+
+    if (admission.status !== AdmissionStatus.ACTIVE) {
+      throw new AdmissionNotActiveException(id);
+    }
+
+    await this.repository.update(id, {
+      diagnosis: dto.diagnosis,
+      attendingDoctorId: dto.attendingDoctorId,
+      primaryNurseId: dto.primaryNurseId,
+      expectedDischargeDate: dto.expectedDischargeDate
+        ? new Date(dto.expectedDischargeDate)
+        : undefined,
+      notes: dto.notes,
+    });
+
+    const updated = await this.repository.findById(id);
+    return this.toResponseDto(updated!);
   }
 
   async findById(id: string): Promise<AdmissionResponseDto> {

--- a/apps/backend/src/modules/admission/dto/index.ts
+++ b/apps/backend/src/modules/admission/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './create-admission.dto';
+export * from './update-admission.dto';
 export * from './transfer.dto';
 export * from './discharge.dto';
 export * from './admission-response.dto';

--- a/apps/backend/src/modules/admission/dto/update-admission.dto.ts
+++ b/apps/backend/src/modules/admission/dto/update-admission.dto.ts
@@ -1,0 +1,46 @@
+import { IsOptional, IsString, IsUUID, IsDateString, MaxLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateAdmissionDto {
+  @ApiPropertyOptional({ description: 'Updated diagnosis', example: 'Acute appendicitis' })
+  @IsOptional()
+  @IsString()
+  diagnosis?: string;
+
+  @ApiPropertyOptional({
+    description: 'Attending doctor ID',
+    example: '550e8400-e29b-41d4-a716-446655440002',
+    format: 'uuid',
+  })
+  @IsOptional()
+  @IsUUID()
+  attendingDoctorId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Primary nurse ID',
+    example: '550e8400-e29b-41d4-a716-446655440003',
+    format: 'uuid',
+  })
+  @IsOptional()
+  @IsUUID()
+  primaryNurseId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Expected discharge date',
+    example: '2025-01-20',
+    format: 'date',
+  })
+  @IsOptional()
+  @IsDateString()
+  expectedDischargeDate?: string;
+
+  @ApiPropertyOptional({
+    description: 'Additional notes',
+    example: 'Patient condition improving',
+    maxLength: 1000,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  notes?: string;
+}

--- a/apps/backend/src/modules/patient/__tests__/patient.service.spec.ts
+++ b/apps/backend/src/modules/patient/__tests__/patient.service.spec.ts
@@ -5,6 +5,7 @@ import { PatientService } from '../patient.service';
 import { PatientRepository } from '../patient.repository';
 import { PatientNumberGenerator } from '../patient-number.generator';
 import { DataMaskingService } from '../data-masking.service';
+import { PrismaService } from '../../../prisma';
 import {
   createTestPatient,
   createTestPatientWithDetail,
@@ -41,6 +42,13 @@ describe('PatientService', () => {
     emit: jest.fn(),
   };
 
+  const mockPrismaService = {
+    patientHistory: {
+      findMany: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+    },
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -48,6 +56,7 @@ describe('PatientService', () => {
         { provide: PatientRepository, useValue: mockRepository },
         { provide: PatientNumberGenerator, useValue: mockPatientNumberGenerator },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        { provide: PrismaService, useValue: mockPrismaService },
         DataMaskingService,
       ],
     }).compile();

--- a/apps/backend/src/modules/patient/patient.controller.ts
+++ b/apps/backend/src/modules/patient/patient.controller.ts
@@ -114,6 +114,36 @@ export class PatientController {
     return this.patientService.findByLegacyId(legacyId, user.role);
   }
 
+  @ApiOperation({ summary: 'Get patient change history' })
+  @ApiParam({ name: 'id', description: 'Patient ID', format: 'uuid' })
+  @ApiQuery({ name: 'page', required: false, description: 'Page number', example: 1 })
+  @ApiQuery({ name: 'limit', required: false, description: 'Items per page', example: 20 })
+  @ApiQuery({
+    name: 'from',
+    required: false,
+    description: 'Start date filter (ISO 8601)',
+    example: '2025-01-01',
+  })
+  @ApiQuery({
+    name: 'to',
+    required: false,
+    description: 'End date filter (ISO 8601)',
+    example: '2025-12-31',
+  })
+  @ApiResponse({ status: 200, description: 'Paginated patient history' })
+  @ApiResponse({ status: 404, description: 'Patient not found' })
+  @Get(':id/history')
+  @RequirePermission(Permissions.PATIENT_READ)
+  async getHistory(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('page') page?: number,
+    @Query('limit') limit?: number,
+    @Query('from') from?: string,
+    @Query('to') to?: string,
+  ) {
+    return this.patientService.findHistory(id, { page, limit, from, to });
+  }
+
   @ApiOperation({ summary: 'Get patient by ID' })
   @ApiParam({ name: 'id', description: 'Patient ID' })
   @ApiResponse({ status: 200, description: 'Patient found', type: PatientResponseDto })

--- a/apps/backend/src/modules/patient/patient.service.ts
+++ b/apps/backend/src/modules/patient/patient.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Patient, PatientDetail } from '@prisma/client';
+import { PrismaService } from '../../prisma';
 import { PatientRepository, PatientWithDetail } from './patient.repository';
 import { PatientNumberGenerator } from './patient-number.generator';
 import { DataMaskingService, UserRole } from './data-masking.service';
@@ -30,6 +31,7 @@ export class PatientService {
     private readonly patientNumberGenerator: PatientNumberGenerator,
     private readonly dataMaskingService: DataMaskingService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly prisma: PrismaService,
   ) {}
 
   async create(dto: CreatePatientDto): Promise<PatientResponseDto> {
@@ -252,6 +254,65 @@ export class PatientService {
       insuranceNumber: insuranceResult.value,
       insuranceCompany: detail.insuranceCompany,
       notes: detail.notes,
+    };
+  }
+
+  async findHistory(
+    patientId: string,
+    options: {
+      page?: number;
+      limit?: number;
+      from?: string;
+      to?: string;
+    },
+  ) {
+    const patient = await this.repository.findById(patientId);
+    if (!patient) {
+      throw new NotFoundException(`Patient ${patientId} not found`);
+    }
+
+    const page = options.page || 1;
+    const limit = options.limit || 20;
+    const where: Record<string, unknown> = { patientId };
+
+    if (options.from || options.to) {
+      const changedAt: Record<string, Date> = {};
+      if (options.from) changedAt.gte = new Date(options.from);
+      if (options.to) changedAt.lte = new Date(options.to);
+      where.changedAt = changedAt;
+    }
+
+    const [data, total] = await Promise.all([
+      this.prisma.patientHistory.findMany({
+        where,
+        orderBy: { changedAt: 'desc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          changer: {
+            select: { id: true, username: true, name: true },
+          },
+        },
+      }),
+      this.prisma.patientHistory.count({ where }),
+    ]);
+
+    return {
+      data: data.map((h) => ({
+        id: h.id,
+        patientId: h.patientId,
+        changedBy: h.changedBy,
+        changerName: h.changer.name || h.changer.username,
+        changedAt: h.changedAt,
+        changeType: h.changeType,
+        fieldName: h.fieldName,
+        oldValue: h.oldValue,
+        newValue: h.newValue,
+      })),
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `PATCH /admissions/:id` endpoint for updating admission details (diagnosis, notes, attending doctor, primary nurse, expected discharge date)
- Reject updates on non-active (discharged/transferred) admissions with 400 error
- Add `GET /patients/:id/history` endpoint with pagination and date range filters
- History response includes changer name and before/after values for each change

## Test Plan
- [ ] `PATCH /admissions/:id` updates allowed fields and returns updated admission
- [ ] Attempting to update a discharged admission returns 400
- [ ] `GET /patients/:id/history` returns paginated change log
- [ ] Date range filtering works (`?from=2025-01-01&to=2025-06-30`)
- [ ] Both endpoints require proper authentication and permissions
- [ ] Existing tests pass with added PrismaService mock

Closes #217