### PR TITLE
fix(config): replace deprecated image domains with remote patterns

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -23,3 +23,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3001
 # Feature Flags
 # -----------------------------------------------------------------------------
 # NEXT_PUBLIC_ENABLE_PWA=true
+
+# -----------------------------------------------------------------------------
+# Image Optimization (Optional)
+# Comma-separated list of allowed image hostnames for production
+# -----------------------------------------------------------------------------
+# NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com,images.example.com

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -26,8 +26,22 @@ const nextConfig = {
 
   // Image optimization configuration
   images: {
-    domains: ['localhost'],
     formats: ['image/avif', 'image/webp'],
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost',
+      },
+      // Add production image domains via NEXT_PUBLIC_IMAGE_DOMAINS env var
+      // e.g., NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com,images.example.com
+      ...(process.env.NEXT_PUBLIC_IMAGE_DOMAINS || '')
+        .split(',')
+        .filter(Boolean)
+        .map((hostname) => ({
+          protocol: 'https',
+          hostname: hostname.trim(),
+        })),
+    ],
   },
 
   // Experimental features


### PR DESCRIPTION
## Summary
- Replace deprecated `images.domains` with `images.remotePatterns` in Next.js config
- Support dynamic production domains via `NEXT_PUBLIC_IMAGE_DOMAINS` env var (comma-separated)
- Keep `localhost` for development, auto-add HTTPS patterns for production hostnames

## Test Plan
- [ ] Images load correctly in development (localhost)
- [ ] No Next.js deprecation warnings
- [ ] Setting `NEXT_PUBLIC_IMAGE_DOMAINS=cdn.example.com` allows images from that domain
- [ ] AVIF and WebP format support maintained

Closes #220