### PR TITLE
feat(api): add uri-based api versioning strategy

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe, Logger } from '@nestjs/common';
+import { ValidationPipe, Logger, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import helmet from 'helmet';
 import { AppModule } from './app.module';
@@ -8,6 +8,15 @@ import { AllExceptionsFilter } from './common/filters';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = new Logger('Bootstrap');
+
+  app.setGlobalPrefix('api', {
+    exclude: ['health', 'health/live', 'health/ready'],
+  });
+
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
 
   app.use(helmet());
 

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -19,7 +19,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/:path*`,
+        destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/api/:path*`,
       },
     ];
   },

--- a/apps/frontend/src/lib/api-client.ts
+++ b/apps/frontend/src/lib/api-client.ts
@@ -1,6 +1,6 @@
 import { useAuthStore } from '@/stores';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const API_BASE_URL = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000'}/api/v1`;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_NETWORK_RETRIES = 2;
 


### PR DESCRIPTION
## Summary
- Add global API prefix `/api` with URI versioning (default v1) to NestJS backend
- Health check endpoints excluded from prefix for K8s probe compatibility
- Update frontend `api-client.ts` base URL to include `/api/v1`
- Fix Next.js rewrite rules to properly proxy `/api/:path*` to backend

Closes #221

## Test Plan
- [ ] Backend routes respond at `/api/v1/...` paths
- [ ] Health endpoints still accessible at `/health`, `/health/live`, `/health/ready`
- [ ] Frontend API calls work with updated base URL
- [ ] Swagger docs accessible at `/api/docs`