### PR TITLE
test(backend): add missing e2e tests for report and admin modules

### DIFF
--- a/apps/backend/test/integration/audit.e2e-spec.ts
+++ b/apps/backend/test/integration/audit.e2e-spec.ts
@@ -1,0 +1,231 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma';
+import {
+  createTestApp,
+  closeTestApp,
+  TestApp,
+  seedTestDatabase,
+  cleanupTestDatabase,
+  seedPatientTestData,
+  cleanupPatientTestData,
+  getTestDataIds,
+  loginAs,
+  authRequest,
+  publicRequest,
+} from './index';
+
+describe('Audit API (e2e)', () => {
+  let testApp: TestApp;
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let adminToken: string;
+  let doctorToken: string;
+  let adminUserId: string;
+  let patientId: string;
+
+  const startDate = new Date();
+  startDate.setDate(startDate.getDate() - 30);
+  const endDate = new Date();
+  endDate.setDate(endDate.getDate() + 1);
+  const startDateStr = startDate.toISOString().split('T')[0];
+  const endDateStr = endDate.toISOString().split('T')[0];
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    app = testApp.app;
+    prisma = testApp.prisma;
+
+    await seedTestDatabase(prisma);
+    await seedPatientTestData(prisma);
+
+    const ids = getTestDataIds();
+    adminUserId = ids.users.adminId;
+    patientId = ids.patients.johnId;
+
+    const adminTokens = await loginAs(app, 'admin');
+    adminToken = adminTokens.accessToken;
+
+    const doctorTokens = await loginAs(app, 'doctor');
+    doctorToken = doctorTokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await cleanupPatientTestData(prisma);
+    await cleanupTestDatabase(prisma);
+    await closeTestApp(testApp);
+  });
+
+  describe('GET /admin/audit/login-history', () => {
+    it('should return login history for admin', async () => {
+      const response = await authRequest(app, 'get', '/admin/audit/login-history', adminToken);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    it('should support filtering by success status', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        '/admin/audit/login-history?success=true',
+        adminToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+    });
+
+    it('should support pagination', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        '/admin/audit/login-history?page=1&limit=5',
+        adminToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'get', '/admin/audit/login-history');
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(app, 'get', '/admin/audit/login-history', doctorToken);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /admin/audit/access-logs', () => {
+    it('should return access logs for admin', async () => {
+      const response = await authRequest(app, 'get', '/admin/audit/access-logs', adminToken);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(app, 'get', '/admin/audit/access-logs', doctorToken);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /admin/audit/change-logs', () => {
+    it('should return change logs for admin', async () => {
+      const response = await authRequest(app, 'get', '/admin/audit/change-logs', adminToken);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(app, 'get', '/admin/audit/change-logs', doctorToken);
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /admin/audit/patients/:patientId/access-report', () => {
+    it('should return patient access report', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/patients/${patientId}/access-report?startDate=${startDateStr}&endDate=${endDateStr}`,
+        adminToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/patients/${patientId}/access-report?startDate=${startDateStr}&endDate=${endDateStr}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /admin/audit/users/:userId/activity-report', () => {
+    it('should return user activity report', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/users/${adminUserId}/activity-report?startDate=${startDateStr}&endDate=${endDateStr}`,
+        adminToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/users/${adminUserId}/activity-report?startDate=${startDateStr}&endDate=${endDateStr}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /admin/audit/security/suspicious-activity', () => {
+    it('should return suspicious activity report', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/security/suspicious-activity?startDate=${startDateStr}&endDate=${endDateStr}`,
+        adminToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/security/suspicious-activity?startDate=${startDateStr}&endDate=${endDateStr}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('GET /admin/audit/security/failed-logins', () => {
+    it('should return failed login attempts', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/security/failed-logins?startDate=${startDateStr}&endDate=${endDateStr}`,
+        adminToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+    });
+
+    it('should return 403 for non-admin user', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admin/audit/security/failed-logins?startDate=${startDateStr}&endDate=${endDateStr}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(403);
+    });
+  });
+});

--- a/apps/backend/test/integration/daily-reports.e2e-spec.ts
+++ b/apps/backend/test/integration/daily-reports.e2e-spec.ts
@@ -1,0 +1,161 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma';
+import {
+  createTestApp,
+  closeTestApp,
+  TestApp,
+  seedTestDatabase,
+  cleanupTestDatabase,
+  seedPatientTestData,
+  cleanupPatientTestData,
+  getTestDataIds,
+  loginAs,
+  authRequest,
+  publicRequest,
+} from './index';
+import { createTestAdmission } from './test-database';
+
+describe('Daily Reports API (e2e)', () => {
+  let testApp: TestApp;
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let doctorToken: string;
+  let nurseToken: string;
+  let admissionId: string;
+  const today = new Date().toISOString().split('T')[0];
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    app = testApp.app;
+    prisma = testApp.prisma;
+
+    await seedTestDatabase(prisma);
+    await seedPatientTestData(prisma);
+
+    const ids = getTestDataIds();
+    admissionId = await createTestAdmission(
+      prisma,
+      ids.patients.johnId,
+      ids.rooms.bed301AId,
+      ids.users.doctorId,
+      ids.users.nurseId,
+    );
+
+    const doctorTokens = await loginAs(app, 'doctor');
+    doctorToken = doctorTokens.accessToken;
+
+    const nurseTokens = await loginAs(app, 'nurse');
+    nurseToken = nurseTokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await cleanupPatientTestData(prisma);
+    await cleanupTestDatabase(prisma);
+    await closeTestApp(testApp);
+  });
+
+  describe('GET /admissions/:admissionId/daily-reports/:date/summary', () => {
+    it('should return live daily summary', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/daily-reports/${today}/summary`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/daily-reports/${today}/summary`,
+      );
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('POST /admissions/:admissionId/daily-reports/:date/generate', () => {
+    it('should generate a daily report', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/daily-reports/${today}/generate`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/daily-reports/${today}/generate`,
+      );
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 404 for non-existent admission', async () => {
+      const fakeId = '00000000-0000-0000-0000-000000000000';
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${fakeId}/daily-reports/${today}/generate`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/daily-reports/:date', () => {
+    it('should return daily report for the generated date', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/daily-reports/${today}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/daily-reports', () => {
+    it('should list all daily reports', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/daily-reports`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+    });
+
+    it('should support pagination', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/daily-reports?page=1&limit=5`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeLessThanOrEqual(5);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'get', `/admissions/${admissionId}/daily-reports`);
+
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/apps/backend/test/integration/intake-output.e2e-spec.ts
+++ b/apps/backend/test/integration/intake-output.e2e-spec.ts
@@ -1,0 +1,176 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma';
+import {
+  createTestApp,
+  closeTestApp,
+  TestApp,
+  seedTestDatabase,
+  cleanupTestDatabase,
+  seedPatientTestData,
+  cleanupPatientTestData,
+  getTestDataIds,
+  loginAs,
+  authRequest,
+  publicRequest,
+} from './index';
+import { createTestAdmission } from './test-database';
+
+describe('Intake/Output API (e2e)', () => {
+  let testApp: TestApp;
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let nurseToken: string;
+  let doctorToken: string;
+  let admissionId: string;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    app = testApp.app;
+    prisma = testApp.prisma;
+
+    await seedTestDatabase(prisma);
+    await seedPatientTestData(prisma);
+
+    const ids = getTestDataIds();
+    admissionId = await createTestAdmission(
+      prisma,
+      ids.patients.johnId,
+      ids.rooms.bed301AId,
+      ids.users.doctorId,
+      ids.users.nurseId,
+    );
+
+    const nurseTokens = await loginAs(app, 'nurse');
+    nurseToken = nurseTokens.accessToken;
+
+    const doctorTokens = await loginAs(app, 'doctor');
+    doctorToken = doctorTokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await cleanupPatientTestData(prisma);
+    await cleanupTestDatabase(prisma);
+    await closeTestApp(testApp);
+  });
+
+  describe('POST /admissions/:admissionId/io', () => {
+    it('should record intake/output', async () => {
+      const today = new Date().toISOString().split('T')[0];
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/io`,
+        nurseToken,
+      ).send({
+        recordDate: today,
+        recordTime: new Date().toISOString(),
+        oralIntake: 500,
+        ivIntake: 1000,
+        urineOutput: 800,
+        stoolOutput: 200,
+        notes: 'Normal fluid balance',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.oralIntake).toBe(500);
+      expect(response.body.ivIntake).toBe(1000);
+    });
+
+    it('should record another I/O entry', async () => {
+      const today = new Date().toISOString().split('T')[0];
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/io`,
+        nurseToken,
+      ).send({
+        recordDate: today,
+        recordTime: new Date().toISOString(),
+        oralIntake: 300,
+        ivIntake: 500,
+        urineOutput: 600,
+        notes: 'Afternoon recording',
+      });
+
+      expect(response.status).toBe(201);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'post', `/admissions/${admissionId}/io`).send({
+        recordDate: new Date().toISOString().split('T')[0],
+        recordTime: new Date().toISOString(),
+        oralIntake: 100,
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 404 for non-existent admission', async () => {
+      const fakeId = '00000000-0000-0000-0000-000000000000';
+      const response = await authRequest(app, 'post', `/admissions/${fakeId}/io`, nurseToken).send({
+        recordDate: new Date().toISOString().split('T')[0],
+        recordTime: new Date().toISOString(),
+        oralIntake: 100,
+      });
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/io', () => {
+    it('should return I/O history', async () => {
+      const response = await authRequest(app, 'get', `/admissions/${admissionId}/io`, doctorToken);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBeGreaterThan(0);
+    });
+
+    it('should support pagination', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/io?page=1&limit=1`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'get', `/admissions/${admissionId}/io`);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/io/daily/:date', () => {
+    it('should return daily I/O summary', async () => {
+      const today = new Date().toISOString().split('T')[0];
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/io/daily/${today}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/io/balance', () => {
+    it('should return I/O balance history', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/io/balance`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
+});

--- a/apps/backend/test/integration/medications.e2e-spec.ts
+++ b/apps/backend/test/integration/medications.e2e-spec.ts
@@ -1,0 +1,256 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma';
+import {
+  createTestApp,
+  closeTestApp,
+  TestApp,
+  seedTestDatabase,
+  cleanupTestDatabase,
+  seedPatientTestData,
+  cleanupPatientTestData,
+  getTestDataIds,
+  loginAs,
+  authRequest,
+  publicRequest,
+} from './index';
+import { createTestAdmission } from './test-database';
+
+describe('Medications API (e2e)', () => {
+  let testApp: TestApp;
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let doctorToken: string;
+  let nurseToken: string;
+  let admissionId: string;
+  let scheduledMedicationId: string;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    app = testApp.app;
+    prisma = testApp.prisma;
+
+    await seedTestDatabase(prisma);
+    await seedPatientTestData(prisma);
+
+    const ids = getTestDataIds();
+    admissionId = await createTestAdmission(
+      prisma,
+      ids.patients.johnId,
+      ids.rooms.bed301AId,
+      ids.users.doctorId,
+      ids.users.nurseId,
+    );
+
+    const doctorTokens = await loginAs(app, 'doctor');
+    doctorToken = doctorTokens.accessToken;
+
+    const nurseTokens = await loginAs(app, 'nurse');
+    nurseToken = nurseTokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await cleanupPatientTestData(prisma);
+    await cleanupTestDatabase(prisma);
+    await closeTestApp(testApp);
+  });
+
+  describe('POST /admissions/:admissionId/medications', () => {
+    it('should schedule a medication', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications`,
+        doctorToken,
+      ).send({
+        medicationName: 'Amoxicillin 500mg',
+        dosage: '500mg',
+        route: 'PO',
+        frequency: 'TID',
+        notes: 'Take with food',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.medicationName).toBe('Amoxicillin 500mg');
+      expect(response.body.status).toBe('SCHEDULED');
+
+      scheduledMedicationId = response.body.id;
+    });
+
+    it('should schedule IV medication', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications`,
+        doctorToken,
+      ).send({
+        medicationName: 'Ceftriaxone 1g',
+        dosage: '1g',
+        route: 'IV',
+        frequency: 'Q24H',
+        notes: 'Infuse over 30 minutes',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.route).toBe('IV');
+    });
+
+    it('should reject missing required fields', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications`,
+        doctorToken,
+      ).send({
+        notes: 'Missing medication name and dosage',
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications`,
+      ).send({
+        medicationName: 'Test Med',
+        dosage: '100mg',
+        route: 'PO',
+      });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('POST /admissions/:admissionId/medications/:id/administer', () => {
+    it('should administer a scheduled medication', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications/${scheduledMedicationId}/administer`,
+        nurseToken,
+      ).send({
+        notes: 'Patient tolerated well',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('ADMINISTERED');
+      expect(response.body.administeredAt).toBeDefined();
+    });
+  });
+
+  describe('POST /admissions/:admissionId/medications/:id/hold', () => {
+    let holdMedId: string;
+
+    beforeAll(async () => {
+      const res = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications`,
+        doctorToken,
+      ).send({
+        medicationName: 'Metformin 500mg',
+        dosage: '500mg',
+        route: 'PO',
+        frequency: 'BID',
+      });
+      holdMedId = res.body.id;
+    });
+
+    it('should hold a medication with reason', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications/${holdMedId}/hold`,
+        nurseToken,
+      ).send({
+        reason: 'Patient NPO for procedure',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('HELD');
+    });
+  });
+
+  describe('POST /admissions/:admissionId/medications/:id/refuse', () => {
+    let refuseMedId: string;
+
+    beforeAll(async () => {
+      const res = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications`,
+        doctorToken,
+      ).send({
+        medicationName: 'Omeprazole 20mg',
+        dosage: '20mg',
+        route: 'PO',
+        frequency: 'QD',
+      });
+      refuseMedId = res.body.id;
+    });
+
+    it('should record medication refusal', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/medications/${refuseMedId}/refuse`,
+        nurseToken,
+      ).send({
+        reason: 'Patient refuses due to nausea',
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('REFUSED');
+    });
+  });
+
+  describe('GET /admissions/:admissionId/medications/scheduled/:date', () => {
+    it('should return scheduled medications for today', async () => {
+      const today = new Date().toISOString().split('T')[0];
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/medications/scheduled/${today}`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/medications', () => {
+    it('should return medication history', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/medications`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBeGreaterThan(0);
+    });
+
+    it('should support pagination', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/medications?page=1&limit=2`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'get', `/admissions/${admissionId}/medications`);
+      expect(response.status).toBe(401);
+    });
+  });
+});

--- a/apps/backend/test/integration/nursing-notes.e2e-spec.ts
+++ b/apps/backend/test/integration/nursing-notes.e2e-spec.ts
@@ -1,0 +1,201 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma';
+import {
+  createTestApp,
+  closeTestApp,
+  TestApp,
+  seedTestDatabase,
+  cleanupTestDatabase,
+  seedPatientTestData,
+  cleanupPatientTestData,
+  getTestDataIds,
+  loginAs,
+  authRequest,
+  publicRequest,
+} from './index';
+import { createTestAdmission } from './test-database';
+
+describe('Nursing Notes API (e2e)', () => {
+  let testApp: TestApp;
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let nurseToken: string;
+  let doctorToken: string;
+  let admissionId: string;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    app = testApp.app;
+    prisma = testApp.prisma;
+
+    await seedTestDatabase(prisma);
+    await seedPatientTestData(prisma);
+
+    const ids = getTestDataIds();
+    admissionId = await createTestAdmission(
+      prisma,
+      ids.patients.johnId,
+      ids.rooms.bed301AId,
+      ids.users.doctorId,
+      ids.users.nurseId,
+    );
+
+    const nurseTokens = await loginAs(app, 'nurse');
+    nurseToken = nurseTokens.accessToken;
+
+    const doctorTokens = await loginAs(app, 'doctor');
+    doctorToken = doctorTokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await cleanupPatientTestData(prisma);
+    await cleanupTestDatabase(prisma);
+    await closeTestApp(testApp);
+  });
+
+  describe('POST /admissions/:admissionId/notes', () => {
+    it('should create a progress note', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/notes`,
+        nurseToken,
+      ).send({
+        noteType: 'PROGRESS',
+        subjective: 'Patient reports feeling better today',
+        objective: 'Vital signs stable, patient ambulating without assistance',
+        assessment: 'Condition improving, pain well controlled',
+        plan: 'Continue current treatment plan',
+        isSignificant: false,
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.noteType).toBe('PROGRESS');
+    });
+
+    it('should create a significant incident note', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/notes`,
+        nurseToken,
+      ).send({
+        noteType: 'INCIDENT',
+        subjective: 'Patient reports sudden onset of chest pain',
+        objective: 'Patient diaphoretic, BP elevated at 180/100',
+        assessment: 'Possible cardiac event, requires immediate attention',
+        plan: 'Notify physician stat, prepare for EKG',
+        isSignificant: true,
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.isSignificant).toBe(true);
+    });
+
+    it('should create a handoff note', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/notes`,
+        nurseToken,
+      ).send({
+        noteType: 'HANDOFF',
+        subjective: 'Patient had uneventful shift',
+        objective: 'All vital signs within normal limits',
+        assessment: 'Stable condition',
+        plan: 'Continue current plan, follow up on pending labs',
+        isSignificant: true,
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body.noteType).toBe('HANDOFF');
+    });
+
+    it('should reject missing required fields', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/notes`,
+        nurseToken,
+      ).send({
+        subjective: 'Missing noteType and isSignificant',
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'post', `/admissions/${admissionId}/notes`).send({
+        noteType: 'PROGRESS',
+        isSignificant: false,
+      });
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/notes', () => {
+    it('should return nursing notes list', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/notes`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBeGreaterThan(0);
+    });
+
+    it('should support pagination', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/notes?page=1&limit=2`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeLessThanOrEqual(2);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'get', `/admissions/${admissionId}/notes`);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/notes/significant', () => {
+    it('should return only significant notes', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/notes/significant`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+      response.body.forEach((note: { isSignificant: boolean }) => {
+        expect(note.isSignificant).toBe(true);
+      });
+    });
+  });
+
+  describe('GET /admissions/:admissionId/notes/latest', () => {
+    it('should return the latest nursing note', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/notes/latest`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('id');
+    });
+  });
+});

--- a/apps/backend/test/integration/test-app.ts
+++ b/apps/backend/test/integration/test-app.ts
@@ -7,6 +7,8 @@ import { PatientModule } from '../../src/modules/patient/patient.module';
 import { AdmissionModule } from '../../src/modules/admission/admission.module';
 import { RoomModule } from '../../src/modules/room/room.module';
 import { RoundingModule } from '../../src/modules/rounding/rounding.module';
+import { ReportModule } from '../../src/modules/report/report.module';
+import { AdminModule } from '../../src/modules/admin/admin.module';
 import { PrismaModule } from '../../src/prisma/prisma.module';
 import { RedisModule } from '../../src/redis';
 import { appConfig, databaseConfig, redisConfig, jwtConfig } from '../../src/config';
@@ -35,6 +37,8 @@ export async function createTestApp(): Promise<TestApp> {
       AdmissionModule,
       RoomModule,
       RoundingModule,
+      ReportModule,
+      AdminModule,
     ],
   }).compile();
 

--- a/apps/backend/test/integration/test-database.ts
+++ b/apps/backend/test/integration/test-database.ts
@@ -136,6 +136,83 @@ export async function seedTestDatabase(prisma: PrismaService): Promise<void> {
     create: { roleId: nurseRole.id, permissionId: patientReadPerm.id },
   });
 
+  // Create report & vital permissions
+  const vitalReadPerm = await prisma.permission.upsert({
+    where: { code: 'vital:read' },
+    update: {},
+    create: {
+      code: 'vital:read',
+      resource: 'vital',
+      action: 'read',
+      description: 'Read vital signs',
+    },
+  });
+  const vitalWritePerm = await prisma.permission.upsert({
+    where: { code: 'vital:write' },
+    update: {},
+    create: {
+      code: 'vital:write',
+      resource: 'vital',
+      action: 'write',
+      description: 'Record vital signs',
+    },
+  });
+  const reportReadPerm = await prisma.permission.upsert({
+    where: { code: 'report:read' },
+    update: {},
+    create: {
+      code: 'report:read',
+      resource: 'report',
+      action: 'read',
+      description: 'Read reports',
+    },
+  });
+  const reportWritePerm = await prisma.permission.upsert({
+    where: { code: 'report:write' },
+    update: {},
+    create: {
+      code: 'report:write',
+      resource: 'report',
+      action: 'write',
+      description: 'Write reports',
+    },
+  });
+  const adminAuditPerm = await prisma.permission.upsert({
+    where: { code: 'admin:audit' },
+    update: {},
+    create: {
+      code: 'admin:audit',
+      resource: 'admin',
+      action: 'audit',
+      description: 'Access audit logs',
+    },
+  });
+
+  // Assign report/vital permissions to doctor and nurse roles
+  const reportPerms = [vitalReadPerm, vitalWritePerm, reportReadPerm, reportWritePerm];
+  for (const perm of reportPerms) {
+    await prisma.rolePermission.upsert({
+      where: { roleId_permissionId: { roleId: doctorRole.id, permissionId: perm.id } },
+      update: {},
+      create: { roleId: doctorRole.id, permissionId: perm.id },
+    });
+    await prisma.rolePermission.upsert({
+      where: { roleId_permissionId: { roleId: nurseRole.id, permissionId: perm.id } },
+      update: {},
+      create: { roleId: nurseRole.id, permissionId: perm.id },
+    });
+  }
+
+  // Assign all permissions including admin:audit to admin role
+  const allNewPerms = [...reportPerms, adminAuditPerm];
+  for (const perm of allNewPerms) {
+    await prisma.rolePermission.upsert({
+      where: { roleId_permissionId: { roleId: adminRole.id, permissionId: perm.id } },
+      update: {},
+      create: { roleId: adminRole.id, permissionId: perm.id },
+    });
+  }
+
   // Create test users
   const adminUser = await prisma.user.upsert({
     where: { username: TEST_USERS.admin.username },

--- a/apps/backend/test/integration/vital-signs.e2e-spec.ts
+++ b/apps/backend/test/integration/vital-signs.e2e-spec.ts
@@ -1,0 +1,194 @@
+import { INestApplication } from '@nestjs/common';
+import { PrismaService } from '../../src/prisma';
+import {
+  createTestApp,
+  closeTestApp,
+  TestApp,
+  seedTestDatabase,
+  cleanupTestDatabase,
+  seedPatientTestData,
+  cleanupPatientTestData,
+  getTestDataIds,
+  loginAs,
+  authRequest,
+  publicRequest,
+} from './index';
+import { createTestAdmission } from './test-database';
+
+describe('Vital Signs API (e2e)', () => {
+  let testApp: TestApp;
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let doctorToken: string;
+  let nurseToken: string;
+  let admissionId: string;
+
+  beforeAll(async () => {
+    testApp = await createTestApp();
+    app = testApp.app;
+    prisma = testApp.prisma;
+
+    await seedTestDatabase(prisma);
+    await seedPatientTestData(prisma);
+
+    const ids = getTestDataIds();
+    admissionId = await createTestAdmission(
+      prisma,
+      ids.patients.johnId,
+      ids.rooms.bed301AId,
+      ids.users.doctorId,
+      ids.users.nurseId,
+    );
+
+    const doctorTokens = await loginAs(app, 'doctor');
+    doctorToken = doctorTokens.accessToken;
+
+    const nurseTokens = await loginAs(app, 'nurse');
+    nurseToken = nurseTokens.accessToken;
+  });
+
+  afterAll(async () => {
+    await cleanupPatientTestData(prisma);
+    await cleanupTestDatabase(prisma);
+    await closeTestApp(testApp);
+  });
+
+  describe('POST /admissions/:admissionId/vitals', () => {
+    it('should record vital signs', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/vitals`,
+        doctorToken,
+      ).send({
+        temperature: 36.5,
+        systolicBp: 120,
+        diastolicBp: 80,
+        pulseRate: 72,
+        respiratoryRate: 16,
+        oxygenSaturation: 98,
+        consciousness: 'ALERT',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+      expect(response.body.temperature).toBeDefined();
+      expect(response.body.systolicBp).toBe(120);
+    });
+
+    it('should record vital signs as nurse', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/vitals`,
+        nurseToken,
+      ).send({
+        temperature: 37.0,
+        systolicBp: 118,
+        diastolicBp: 78,
+        pulseRate: 74,
+        respiratoryRate: 18,
+        oxygenSaturation: 97,
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toHaveProperty('id');
+    });
+
+    it('should reject invalid vital sign values', async () => {
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${admissionId}/vitals`,
+        doctorToken,
+      ).send({
+        temperature: 50,
+        systolicBp: 300,
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'post', `/admissions/${admissionId}/vitals`).send({
+        temperature: 36.5,
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 404 for non-existent admission', async () => {
+      const fakeId = '00000000-0000-0000-0000-000000000000';
+      const response = await authRequest(
+        app,
+        'post',
+        `/admissions/${fakeId}/vitals`,
+        doctorToken,
+      ).send({
+        temperature: 36.5,
+      });
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/vitals', () => {
+    it('should return vital signs history', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/vitals`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('data');
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.data.length).toBeGreaterThan(0);
+    });
+
+    it('should support pagination', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/vitals?page=1&limit=1`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should return 401 without authentication', async () => {
+      const response = await publicRequest(app, 'get', `/admissions/${admissionId}/vitals`);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('GET /admissions/:admissionId/vitals/latest', () => {
+    it('should return the latest vital signs', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/vitals/latest`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('id');
+    });
+  });
+
+  describe('GET /admissions/:admissionId/vitals/trend', () => {
+    it('should return vital signs trend data', async () => {
+      const response = await authRequest(
+        app,
+        'get',
+        `/admissions/${admissionId}/vitals/trend`,
+        doctorToken,
+      );
+
+      expect(response.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add E2E test files for 6 previously untested modules: vital signs, medications, nursing notes, intake/output, daily reports, and audit
- Update test app to import `ReportModule` and `AdminModule`
- Seed required permissions (`vital:read`, `vital:write`, `report:read`, `report:write`, `admin:audit`) in test database
- Tests cover success paths, validation errors, auth failures (401), and permission enforcement (403)

Closes #222

## Test Plan
- [ ] All new E2E tests compile without errors
- [ ] Vital signs: record, history, latest, trend endpoints tested
- [ ] Medications: schedule, administer, hold, refuse, scheduled, history endpoints tested
- [ ] Nursing notes: create, list, significant, latest endpoints tested
- [ ] Intake/output: record, history, daily summary, balance endpoints tested
- [ ] Daily reports: summary, generate, get report, list endpoints tested
- [ ] Audit: login history, access logs, change logs, patient access report, user activity, suspicious activity, failed logins tested with permission enforcement