### PR TITLE
feat(report): add amendment endpoints for vital signs, medications, and nursing notes

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -52,7 +52,9 @@ model User {
   intakeOutputsRecorded   IntakeOutput[] @relation("IORecorder")
   medicationsPrescribed   Medication[]   @relation("MedicationPrescriber")
   medicationsAdministered Medication[]   @relation("MedicationAdministrator")
+  medicationsCancelled    Medication[]   @relation("MedicationCanceller")
   nursingNotesRecorded    NursingNote[]  @relation("NursingNoteRecorder")
+  vitalSignsAmended       VitalSign[]    @relation("VitalSignAmender")
   dailyReportsGenerated   DailyReport[]  @relation("DailyReportGenerator")
   roundsAsDoctor          Round[]        @relation("RoundLeadDoctor")
   roundsCreated           Round[]        @relation("RoundCreator")
@@ -539,6 +541,8 @@ enum MedicationStatus {
   HELD
   REFUSED
   MISSED
+  CANCELLED
+  DISCONTINUED
 
   @@schema("report")
 }
@@ -573,6 +577,7 @@ enum NoteType {
   EDUCATION
   DISCHARGE_PLANNING
   PHONE_CALL
+  ADDENDUM
 
   @@schema("report")
 }
@@ -607,15 +612,24 @@ model VitalSign {
   notes            String?        @db.Text
   hasAlert         Boolean        @default(false) @map("has_alert")
   createdAt        DateTime       @default(now()) @map("created_at") @db.Timestamptz
+  // Amendment fields (correction record chain)
+  amendedFromId    String?        @map("amended_from_id") @db.Uuid
+  amendedBy        String?        @map("amended_by") @db.Uuid
+  amendmentReason  String?        @map("amendment_reason") @db.Text
+  isAmended        Boolean        @default(false) @map("is_amended")
 
   // Relations
-  admission Admission @relation(fields: [admissionId], references: [id], onDelete: Restrict)
-  measurer  User      @relation("VitalSignMeasurer", fields: [measuredBy], references: [id], onDelete: Restrict)
+  admission   Admission  @relation(fields: [admissionId], references: [id], onDelete: Restrict)
+  measurer    User       @relation("VitalSignMeasurer", fields: [measuredBy], references: [id], onDelete: Restrict)
+  amendedFrom VitalSign? @relation("VitalSignAmendment", fields: [amendedFromId], references: [id], onDelete: SetNull)
+  amendments  VitalSign[] @relation("VitalSignAmendment")
+  amender     User?      @relation("VitalSignAmender", fields: [amendedBy], references: [id], onDelete: SetNull)
 
   @@index([admissionId, measuredAt(sort: Desc)])
   @@index([measuredAt])
   @@index([hasAlert])
   @@index([measuredBy])
+  @@index([amendedFromId])
   @@map("vital_signs")
   @@schema("report")
 }
@@ -672,11 +686,16 @@ model Medication {
   holdReason     String?          @map("hold_reason") @db.Text
   notes          String?          @db.Text
   createdAt      DateTime         @default(now()) @map("created_at") @db.Timestamptz
+  // Cancellation/discontinuation fields
+  cancelledBy    String?          @map("cancelled_by") @db.Uuid
+  cancelledAt    DateTime?        @map("cancelled_at") @db.Timestamptz
+  cancelReason   String?          @map("cancel_reason") @db.Text
 
   // Relations
   admission     Admission @relation(fields: [admissionId], references: [id], onDelete: Restrict)
   prescriber    User?     @relation("MedicationPrescriber", fields: [prescribedBy], references: [id], onDelete: SetNull)
   administrator User?     @relation("MedicationAdministrator", fields: [administeredBy], references: [id], onDelete: SetNull)
+  canceller     User?     @relation("MedicationCanceller", fields: [cancelledBy], references: [id], onDelete: SetNull)
 
   @@index([admissionId, administeredAt])
   @@index([admissionId, status])
@@ -690,30 +709,35 @@ model Medication {
 
 /// NursingNote entity for nursing documentation (SOAP format)
 model NursingNote {
-  id            String   @id @default(uuid()) @db.Uuid
-  admissionId   String   @map("admission_id") @db.Uuid
-  noteType      NoteType @map("note_type")
+  id            String       @id @default(uuid()) @db.Uuid
+  admissionId   String       @map("admission_id") @db.Uuid
+  noteType      NoteType     @map("note_type")
   // SOAP Format
-  subjective    String?  @db.Text
-  objective     String?  @db.Text
-  assessment    String?  @db.Text
-  plan          String?  @db.Text
+  subjective    String?      @db.Text
+  objective     String?      @db.Text
+  assessment    String?      @db.Text
+  plan          String?      @db.Text
   // Metadata
-  recordedAt    DateTime @map("recorded_at") @db.Timestamptz
-  recordedBy    String   @map("recorded_by") @db.Uuid
-  isSignificant Boolean  @default(false) @map("is_significant")
-  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz
+  recordedAt    DateTime     @map("recorded_at") @db.Timestamptz
+  recordedBy    String       @map("recorded_by") @db.Uuid
+  isSignificant Boolean      @default(false) @map("is_significant")
+  createdAt     DateTime     @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt     DateTime     @updatedAt @map("updated_at") @db.Timestamptz
+  // Addendum support (references parent note)
+  parentNoteId  String?      @map("parent_note_id") @db.Uuid
 
   // Relations
-  admission Admission @relation(fields: [admissionId], references: [id], onDelete: Restrict)
-  recorder  User      @relation("NursingNoteRecorder", fields: [recordedBy], references: [id], onDelete: Restrict)
+  admission  Admission     @relation(fields: [admissionId], references: [id], onDelete: Restrict)
+  recorder   User          @relation("NursingNoteRecorder", fields: [recordedBy], references: [id], onDelete: Restrict)
+  parentNote NursingNote?  @relation("NursingNoteAddendum", fields: [parentNoteId], references: [id], onDelete: SetNull)
+  addendums  NursingNote[] @relation("NursingNoteAddendum")
 
   @@index([admissionId, recordedAt(sort: Desc)])
   @@index([admissionId, noteType])
   @@index([recordedAt])
   @@index([recordedBy])
   @@index([isSignificant])
+  @@index([parentNoteId])
   @@map("nursing_notes")
   @@schema("report")
 }

--- a/apps/backend/src/modules/report/dto/amend-vital-signs.dto.ts
+++ b/apps/backend/src/modules/report/dto/amend-vital-signs.dto.ts
@@ -1,0 +1,16 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { RecordVitalSignsDto } from './record-vital-signs.dto';
+
+/**
+ * DTO for amending a vital signs record.
+ * Creates a new corrected record referencing the original.
+ */
+export class AmendVitalSignsDto extends RecordVitalSignsDto {
+  @ApiProperty({
+    description: 'Reason for amending the vital signs record',
+    example: 'Incorrect temperature reading due to faulty thermometer',
+  })
+  @IsString()
+  reason: string;
+}

--- a/apps/backend/src/modules/report/dto/index.ts
+++ b/apps/backend/src/modules/report/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './record-vital-signs.dto';
+export * from './amend-vital-signs.dto';
 export * from './get-vital-history.dto';
 export * from './get-trend.dto';
 export * from './vital-sign-response.dto';

--- a/apps/backend/src/modules/report/dto/medication.dto.ts
+++ b/apps/backend/src/modules/report/dto/medication.dto.ts
@@ -146,6 +146,30 @@ export class GetMedicationHistoryDto {
 }
 
 /**
+ * DTO for cancelling medication
+ */
+export class CancelMedicationDto {
+  @ApiProperty({
+    description: 'Reason for cancelling the medication',
+    example: 'Medication no longer needed per physician order',
+  })
+  @IsString()
+  reason: string;
+}
+
+/**
+ * DTO for discontinuing medication
+ */
+export class DiscontinueMedicationDto {
+  @ApiProperty({
+    description: 'Reason for discontinuing the medication',
+    example: 'Adverse reaction observed',
+  })
+  @IsString()
+  reason: string;
+}
+
+/**
  * Medication response DTO
  */
 export class MedicationResponseDto {
@@ -191,6 +215,15 @@ export class MedicationResponseDto {
 
   @ApiPropertyOptional({ description: 'Additional notes', nullable: true })
   notes: string | null;
+
+  @ApiPropertyOptional({ description: 'User ID who cancelled the medication', nullable: true })
+  cancelledBy: string | null;
+
+  @ApiPropertyOptional({ description: 'Time when medication was cancelled', nullable: true })
+  cancelledAt: Date | null;
+
+  @ApiPropertyOptional({ description: 'Reason for cancellation', nullable: true })
+  cancelReason: string | null;
 
   @ApiProperty({ description: 'Record creation timestamp' })
   createdAt: Date;

--- a/apps/backend/src/modules/report/dto/nursing-note.dto.ts
+++ b/apps/backend/src/modules/report/dto/nursing-note.dto.ts
@@ -49,6 +49,26 @@ export class CreateNursingNoteDto {
 }
 
 /**
+ * DTO for adding an addendum to an existing nursing note
+ */
+export class CreateAddendumDto {
+  @ApiProperty({
+    description: 'Addendum text to append to the original note',
+    example: 'Patient also reports mild dizziness since this morning',
+  })
+  @IsString()
+  content: string;
+
+  @ApiPropertyOptional({
+    description: 'Whether the addendum is significant for handoff',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isSignificant?: boolean;
+}
+
+/**
  * DTO for querying nursing notes
  */
 export class GetNursingNotesDto {
@@ -127,6 +147,9 @@ export class NursingNoteResponseDto {
 
   @ApiProperty({ description: 'Record last update timestamp' })
   updatedAt: Date;
+
+  @ApiPropertyOptional({ description: 'Parent note ID for addendums', nullable: true })
+  parentNoteId: string | null;
 }
 
 /**

--- a/apps/backend/src/modules/report/dto/vital-sign-response.dto.ts
+++ b/apps/backend/src/modules/report/dto/vital-sign-response.dto.ts
@@ -86,6 +86,18 @@ export class VitalSignResponseDto {
 
   @ApiProperty({ description: 'Record creation timestamp' })
   createdAt: Date;
+
+  @ApiPropertyOptional({ description: 'ID of original record this amends', nullable: true })
+  amendedFromId: string | null;
+
+  @ApiPropertyOptional({ description: 'User ID who made the amendment', nullable: true })
+  amendedBy: string | null;
+
+  @ApiPropertyOptional({ description: 'Reason for the amendment', nullable: true })
+  amendmentReason: string | null;
+
+  @ApiProperty({ description: 'Whether this record has been amended', example: false })
+  isAmended: boolean;
 }
 
 /**

--- a/apps/backend/src/modules/report/medication.controller.ts
+++ b/apps/backend/src/modules/report/medication.controller.ts
@@ -8,6 +8,8 @@ import {
   AdministerMedicationDto,
   HoldMedicationDto,
   RefuseMedicationDto,
+  CancelMedicationDto,
+  DiscontinueMedicationDto,
   GetMedicationHistoryDto,
   MedicationResponseDto,
   PaginatedMedicationResponseDto,
@@ -127,6 +129,58 @@ export class MedicationController {
     @CurrentUser() user: { id: string },
   ): Promise<MedicationResponseDto> {
     return this.medicationService.refuse(id, dto, user.id);
+  }
+
+  /**
+   * Cancel medication
+   * POST /admissions/:admissionId/medications/:id/cancel
+   */
+  @ApiOperation({ summary: 'Cancel a scheduled medication' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Medication UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medication cancelled successfully',
+    type: MedicationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid medication status for cancellation' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Medication not found' })
+  @Post(':id/cancel')
+  @RequirePermission('report:write')
+  async cancel(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: CancelMedicationDto,
+    @CurrentUser() user: { id: string },
+  ): Promise<MedicationResponseDto> {
+    return this.medicationService.cancel(id, dto, user.id);
+  }
+
+  /**
+   * Discontinue medication
+   * POST /admissions/:admissionId/medications/:id/discontinue
+   */
+  @ApiOperation({ summary: 'Discontinue a medication' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Medication UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Medication discontinued successfully',
+    type: MedicationResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid medication status for discontinuation' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Medication not found' })
+  @Post(':id/discontinue')
+  @RequirePermission('report:write')
+  async discontinue(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: DiscontinueMedicationDto,
+    @CurrentUser() user: { id: string },
+  ): Promise<MedicationResponseDto> {
+    return this.medicationService.discontinue(id, dto, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/medication.service.ts
+++ b/apps/backend/src/modules/report/medication.service.ts
@@ -7,6 +7,8 @@ import {
   AdministerMedicationDto,
   HoldMedicationDto,
   RefuseMedicationDto,
+  CancelMedicationDto,
+  DiscontinueMedicationDto,
   GetMedicationHistoryDto,
   MedicationResponseDto,
   PaginatedMedicationResponseDto,
@@ -160,6 +162,74 @@ export class MedicationService {
   }
 
   /**
+   * Cancel medication
+   */
+  async cancel(
+    medicationId: string,
+    dto: CancelMedicationDto,
+    userId: string,
+  ): Promise<MedicationResponseDto> {
+    const medication = await this.medicationRepo.findById(medicationId);
+
+    if (!medication) {
+      throw new NotFoundException(`Medication ${medicationId} not found`);
+    }
+
+    if (
+      medication.status !== MedicationStatus.SCHEDULED &&
+      medication.status !== MedicationStatus.HELD
+    ) {
+      throw new BadRequestException(`Cannot cancel medication with status ${medication.status}`);
+    }
+
+    const updated = await this.medicationRepo.update(medicationId, {
+      status: MedicationStatus.CANCELLED,
+      cancelledBy: userId,
+      cancelledAt: new Date(),
+      cancelReason: dto.reason,
+    });
+
+    this.logger.log(`Medication ${medicationId} cancelled by user ${userId}: ${dto.reason}`);
+
+    return this.toResponseDto(updated);
+  }
+
+  /**
+   * Discontinue medication
+   */
+  async discontinue(
+    medicationId: string,
+    dto: DiscontinueMedicationDto,
+    userId: string,
+  ): Promise<MedicationResponseDto> {
+    const medication = await this.medicationRepo.findById(medicationId);
+
+    if (!medication) {
+      throw new NotFoundException(`Medication ${medicationId} not found`);
+    }
+
+    if (
+      medication.status !== MedicationStatus.SCHEDULED &&
+      medication.status !== MedicationStatus.HELD
+    ) {
+      throw new BadRequestException(
+        `Cannot discontinue medication with status ${medication.status}`,
+      );
+    }
+
+    const updated = await this.medicationRepo.update(medicationId, {
+      status: MedicationStatus.DISCONTINUED,
+      cancelledBy: userId,
+      cancelledAt: new Date(),
+      cancelReason: dto.reason,
+    });
+
+    this.logger.log(`Medication ${medicationId} discontinued by user ${userId}: ${dto.reason}`);
+
+    return this.toResponseDto(updated);
+  }
+
+  /**
    * Get scheduled medications for a date
    */
   async getScheduled(admissionId: string, date: Date): Promise<MedicationResponseDto[]> {
@@ -227,6 +297,9 @@ export class MedicationService {
     status: string;
     holdReason: string | null;
     notes: string | null;
+    cancelledBy: string | null;
+    cancelledAt: Date | null;
+    cancelReason: string | null;
     createdAt: Date;
   }): MedicationResponseDto {
     return {
@@ -242,6 +315,9 @@ export class MedicationService {
       status: medication.status as MedicationResponseDto['status'],
       holdReason: medication.holdReason,
       notes: medication.notes,
+      cancelledBy: medication.cancelledBy,
+      cancelledAt: medication.cancelledAt,
+      cancelReason: medication.cancelReason,
       createdAt: medication.createdAt,
     };
   }

--- a/apps/backend/src/modules/report/nursing-note.controller.ts
+++ b/apps/backend/src/modules/report/nursing-note.controller.ts
@@ -5,6 +5,7 @@ import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import {
   CreateNursingNoteDto,
+  CreateAddendumDto,
   GetNursingNotesDto,
   NursingNoteResponseDto,
   PaginatedNursingNotesResponseDto,
@@ -47,6 +48,33 @@ export class NursingNoteController {
     @CurrentUser() user: { id: string },
   ): Promise<NursingNoteResponseDto> {
     return this.noteService.create(admissionId, dto, user.id);
+  }
+
+  /**
+   * Add addendum to nursing note
+   * POST /admissions/:admissionId/notes/:id/addendum
+   */
+  @ApiOperation({ summary: 'Add an addendum to an existing nursing note' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Nursing note UUID' })
+  @ApiResponse({
+    status: 201,
+    description: 'Addendum added successfully',
+    type: NursingNoteResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Nursing note not found' })
+  @Post(':id/addendum')
+  @RequirePermission('report:write')
+  async addAddendum(
+    @Param('admissionId', ParseUUIDPipe) admissionId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: CreateAddendumDto,
+    @CurrentUser() user: { id: string },
+  ): Promise<NursingNoteResponseDto> {
+    return this.noteService.addAddendum(admissionId, id, dto, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/nursing-note.service.ts
+++ b/apps/backend/src/modules/report/nursing-note.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { AdmissionStatus } from '@prisma/client';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { AdmissionStatus, NoteType } from '@prisma/client';
 import { PrismaService } from '../../prisma';
 import { NursingNoteRepository } from './nursing-note.repository';
 import {
   CreateNursingNoteDto,
+  CreateAddendumDto,
   GetNursingNotesDto,
   NursingNoteResponseDto,
   PaginatedNursingNotesResponseDto,
@@ -64,6 +65,46 @@ export class NursingNoteService {
     );
 
     return this.toResponseDto(note);
+  }
+
+  /**
+   * Add addendum to an existing nursing note
+   */
+  async addAddendum(
+    admissionId: string,
+    noteId: string,
+    dto: CreateAddendumDto,
+    userId: string,
+  ): Promise<NursingNoteResponseDto> {
+    // 1. Find original note
+    const originalNote = await this.noteRepo.findById(noteId);
+    if (!originalNote) {
+      throw new NotFoundException(`Nursing note ${noteId} not found`);
+    }
+
+    if (originalNote.admissionId !== admissionId) {
+      throw new NotFoundException(`Nursing note ${noteId} not found for admission ${admissionId}`);
+    }
+
+    // 2. Create addendum note referencing the parent
+    const addendum = await this.prisma.nursingNote.create({
+      data: {
+        admissionId,
+        noteType: NoteType.ADDENDUM,
+        subjective: dto.content,
+        objective: null,
+        assessment: null,
+        plan: null,
+        recordedAt: new Date(),
+        recordedBy: userId,
+        isSignificant: dto.isSignificant ?? false,
+        parentNoteId: noteId,
+      },
+    });
+
+    this.logger.log(`Addendum added to nursing note ${noteId} by user ${userId}`);
+
+    return this.toResponseDto(addendum);
   }
 
   /**
@@ -155,6 +196,7 @@ export class NursingNoteService {
     isSignificant: boolean;
     createdAt: Date;
     updatedAt: Date;
+    parentNoteId?: string | null;
   }): NursingNoteResponseDto {
     return {
       id: note.id,
@@ -169,6 +211,7 @@ export class NursingNoteService {
       isSignificant: note.isSignificant,
       createdAt: note.createdAt,
       updatedAt: note.updatedAt,
+      parentNoteId: note.parentNoteId ?? null,
     };
   }
 }

--- a/apps/backend/src/modules/report/vital-sign.controller.ts
+++ b/apps/backend/src/modules/report/vital-sign.controller.ts
@@ -5,6 +5,7 @@ import { ParseUUIDPipe, JwtAuthGuard, CurrentUser } from '../../common';
 import { PermissionGuard, RequirePermission } from '../auth';
 import {
   RecordVitalSignsDto,
+  AmendVitalSignsDto,
   GetVitalHistoryDto,
   GetTrendDto,
   VitalSignResponseDto,
@@ -49,6 +50,33 @@ export class VitalSignController {
     @CurrentUser() user: { id: string },
   ): Promise<VitalSignResponseDto> {
     return this.vitalSignService.record(admissionId, dto, user.id);
+  }
+
+  /**
+   * Amend vital signs record
+   * POST /admissions/:admissionId/vitals/:id/amend
+   */
+  @ApiOperation({ summary: 'Amend a vital signs record' })
+  @ApiParam({ name: 'admissionId', description: 'Admission UUID' })
+  @ApiParam({ name: 'id', description: 'Vital sign record UUID to amend' })
+  @ApiResponse({
+    status: 201,
+    description: 'Vital signs amended successfully',
+    type: VitalSignResponseDto,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - insufficient permissions' })
+  @ApiResponse({ status: 404, description: 'Vital sign record not found' })
+  @Post(':id/amend')
+  @RequirePermission('vital:write')
+  async amend(
+    @Param('admissionId', ParseUUIDPipe) admissionId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AmendVitalSignsDto,
+    @CurrentUser() user: { id: string },
+  ): Promise<VitalSignResponseDto> {
+    return this.vitalSignService.amend(admissionId, id, dto, user.id);
   }
 
   /**

--- a/apps/backend/src/modules/report/vital-sign.service.ts
+++ b/apps/backend/src/modules/report/vital-sign.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { VitalSign, AdmissionStatus } from '@prisma/client';
 import { PrismaService } from '../../prisma';
@@ -6,6 +6,7 @@ import { VitalSignRepository } from './vital-sign.repository';
 import { VitalSigns, VitalAlert } from './value-objects';
 import {
   RecordVitalSignsDto,
+  AmendVitalSignsDto,
   GetVitalHistoryDto,
   GetTrendDto,
   VitalSignResponseDto,
@@ -113,6 +114,79 @@ export class VitalSignService {
     }
 
     return this.toResponseDto(vitalSign, alerts);
+  }
+
+  /**
+   * Amend vital signs record
+   * Creates a new corrected record referencing the original
+   */
+  async amend(
+    admissionId: string,
+    vitalSignId: string,
+    dto: AmendVitalSignsDto,
+    userId: string,
+  ): Promise<VitalSignResponseDto> {
+    // 1. Find original record
+    const original = await this.vitalRepo.findById(vitalSignId);
+    if (!original) {
+      throw new NotFoundException(`Vital sign record ${vitalSignId} not found`);
+    }
+
+    if (original.admissionId !== admissionId) {
+      throw new NotFoundException(
+        `Vital sign record ${vitalSignId} not found for admission ${admissionId}`,
+      );
+    }
+
+    // 2. Create value object for new readings
+    const vitals = new VitalSigns(
+      dto.temperature ?? null,
+      dto.systolicBp ?? null,
+      dto.diastolicBp ?? null,
+      dto.pulseRate ?? null,
+      dto.respiratoryRate ?? null,
+      dto.oxygenSaturation ?? null,
+      dto.bloodGlucose ?? null,
+      dto.painScore ?? null,
+      dto.consciousness ?? null,
+    );
+
+    const alerts = vitals.getAlerts();
+    const hasAlert = alerts.length > 0;
+    const measuredAt = dto.measuredAt ? new Date(dto.measuredAt) : original.measuredAt;
+
+    // 3. Create amended record and mark original in a transaction
+    const [amended] = await this.prisma.$transaction([
+      this.prisma.vitalSign.create({
+        data: {
+          admissionId,
+          temperature: dto.temperature ?? null,
+          systolicBp: dto.systolicBp ?? null,
+          diastolicBp: dto.diastolicBp ?? null,
+          pulseRate: dto.pulseRate ?? null,
+          respiratoryRate: dto.respiratoryRate ?? null,
+          oxygenSaturation: dto.oxygenSaturation ?? null,
+          bloodGlucose: dto.bloodGlucose ?? null,
+          painScore: dto.painScore ?? null,
+          consciousness: dto.consciousness ?? null,
+          measuredAt,
+          measuredBy: original.measuredBy,
+          notes: dto.notes ?? null,
+          hasAlert,
+          amendedFromId: vitalSignId,
+          amendedBy: userId,
+          amendmentReason: dto.reason,
+        },
+      }),
+      this.prisma.vitalSign.update({
+        where: { id: vitalSignId },
+        data: { isAmended: true },
+      }),
+    ]);
+
+    this.logger.log(`Vital sign ${vitalSignId} amended by user ${userId}: ${dto.reason}`);
+
+    return this.toResponseDto(amended, alerts);
   }
 
   /**
@@ -301,6 +375,10 @@ export class VitalSignService {
       hasAlert: vitalSign.hasAlert,
       alerts: computedAlerts,
       createdAt: vitalSign.createdAt,
+      amendedFromId: vitalSign.amendedFromId,
+      amendedBy: vitalSign.amendedBy,
+      amendmentReason: vitalSign.amendmentReason,
+      isAmended: vitalSign.isAmended,
     };
   }
 }

--- a/apps/backend/test/factories/medication.factory.ts
+++ b/apps/backend/test/factories/medication.factory.ts
@@ -34,6 +34,9 @@ export function createTestMedication(overrides?: Partial<Medication>): Medicatio
     pharmacyVerified: false,
     holdReason: null,
     notes: faker.lorem.sentence(),
+    cancelledBy: null,
+    cancelledAt: null,
+    cancelReason: null,
     createdAt: now,
     ...overrides,
   };

--- a/apps/backend/test/factories/nursing-note.factory.ts
+++ b/apps/backend/test/factories/nursing-note.factory.ts
@@ -22,6 +22,7 @@ export function createTestNursingNote(overrides?: Partial<NursingNote>): Nursing
     isSignificant: faker.datatype.boolean(),
     createdAt: now,
     updatedAt: now,
+    parentNoteId: null,
     ...overrides,
   };
 }

--- a/apps/backend/test/factories/vital-sign.factory.ts
+++ b/apps/backend/test/factories/vital-sign.factory.ts
@@ -28,6 +28,10 @@ export function createTestVitalSign(overrides?: Partial<VitalSign>): VitalSign {
     notes: null,
     hasAlert: false,
     createdAt: now,
+    amendedFromId: null,
+    amendedBy: null,
+    amendmentReason: null,
+    isAmended: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Add vital signs amendment endpoint (`POST /:id/amend`) that creates corrected records referencing originals
- Add medication cancel/discontinue endpoints (`POST /:id/cancel`, `POST /:id/discontinue`) for clinical workflow status transitions
- Add nursing note addendum endpoint (`POST /:id/addendum`) for appending to existing notes
- Update Prisma schema with amendment fields, self-relations, and new enum values (`CANCELLED`, `DISCONTINUED`, `ADDENDUM`)
- Update DTOs, services, controllers, and test factories to support new fields

## Test plan
- [ ] TypeScript compilation passes
- [ ] Existing unit tests pass with updated factories
- [ ] E2E tests pass with new endpoint coverage
- [ ] Verify amendment records correctly reference originals
- [ ] Verify medication status transition validation (only SCHEDULED/HELD can be cancelled/discontinued)

Closes #224