### PR TITLE
docs(api): fix miscellaneous endpoint path and field discrepancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,10 +375,12 @@ See [Security Documentation](docs/kubernetes/security.md) for complete security 
 
 | Phase       | Period    | Focus                                        |
 | ----------- | --------- | -------------------------------------------- |
-| **Phase 1** | Month 1-2 | Foundation (Auth, Patient, Room Management)  |
-| **Phase 2** | Month 3-4 | Core Features (Admission/Discharge, Reports) |
-| **Phase 3** | Month 5   | Advanced Features (Rounds, Statistics)       |
-| **Phase 4** | Month 6   | Stabilization & Launch                       |
+| **Phase 1** | Month 1   | Foundation (Auth, Patient, Room Management)  |
+| **Phase 2** | Month 2-3 | Core Features (Admission/Discharge, Reports) |
+| **Phase 3** | Month 4   | Advanced Features (Rounds, Statistics)       |
+| **Phase 4** | Month 5   | Stabilization & Launch                       |
+
+> Total estimated duration: **4–5 months** (aligns with PRD project schedule).
 
 ---
 

--- a/docs/reference/02-design/api-specification.md
+++ b/docs/reference/02-design/api-specification.md
@@ -424,10 +424,18 @@ GET /api/v1/patients/{patientId}
   "gender": "MALE",
   "bloodType": "A+",
   "phone": "010-1234-5678",
-  "emergencyContact": "Jane Doe",
-  "emergencyPhone": "010-9876-5432",
+  "emergencyContactName": "Jane Doe",
+  "emergencyContactPhone": "010-9876-5432",
+  "emergencyContactRelation": "Spouse",
   "address": "123 Teheran-ro, Gangnam-gu, Seoul",
-  "allergies": ["Penicillin"],
+  "detail": {
+    "allergies": "Penicillin",
+    "medicalHistory": null,
+    "insuranceType": null,
+    "insuranceNumber": null,
+    "insuranceCompany": null,
+    "notes": null
+  },
   "currentAdmission": {
     "id": "660e8400-e29b-41d4-a716-446655440001",
     "admissionNumber": "A2025123456",
@@ -473,16 +481,15 @@ POST /api/v1/patients
 
 ```json
 {
-  "patientNumber": "P2025001234",
   "name": "John Doe",
   "birthDate": "1990-05-15",
   "gender": "MALE",
   "bloodType": "A+",
   "phone": "010-1234-5678",
-  "emergencyContact": "Jane Doe",
-  "emergencyPhone": "010-9876-5432",
-  "address": "123 Teheran-ro, Gangnam-gu, Seoul",
-  "allergies": ["Penicillin"]
+  "emergencyContactName": "Jane Doe",
+  "emergencyContactPhone": "010-9876-5432",
+  "emergencyContactRelation": "Spouse",
+  "address": "123 Teheran-ro, Gangnam-gu, Seoul"
 }
 ```
 
@@ -730,7 +737,7 @@ GET /api/v1/rooms/dashboard/floor/{floorId}
 ### 4.3 Get Available Beds
 
 ```http
-GET /api/v1/beds/available
+GET /api/v1/rooms/beds/available
 ```
 
 **Query Parameters**
@@ -1500,6 +1507,26 @@ GET /api/v1/rounds
 | scheduledDateTo   | date   | End date filter                                    |
 | page              | number | Page number (default: 1)                           |
 | limit             | number | Items per page (default: 20, max: 100)             |
+
+### 7.2.1 Get Round by Round Number
+
+```http
+GET /api/v1/rounds/by-number/{roundNumber}
+```
+
+**Path Parameters**
+
+| Parameter   | Type   | Description                             |
+| ----------- | ------ | --------------------------------------- |
+| roundNumber | string | Round number (e.g., `RND-20240101-001`) |
+
+**Response (200 OK)**: Single round object (same shape as 7.3 Get Round Detail response).
+
+**Error Responses**
+
+| HTTP | Code            | Description                           |
+| ---- | --------------- | ------------------------------------- |
+| 404  | ROUND_NOT_FOUND | Round with specified number not found |
 
 ### 7.3 Get Round Detail
 


### PR DESCRIPTION
## What

### Summary
Fixes 5 targeted discrepancies between the API specification, controller code, DTO classes,
and project documentation found in issue #272.

### Change Type
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [x] Documentation
- [ ] Test

### Affected Components
- `docs/reference/02-design/api-specification.md`
- `README.md`

## Why

### Related Issues
Closes #272

### Motivation
Incorrect endpoint paths, field names, and project timeline cause confusion for developers
referencing the documentation. All changes are verified against actual controller decorators,
DTO class properties, and PRD content.

## Where

### Files Changed
| File | Change |
|------|--------|
| `docs/reference/02-design/api-specification.md` | 5 targeted fixes |
| `README.md` | Timeline alignment with PRD |

## How

### Fixes Applied

| # | Location | Old | New | Source Verified |
|---|----------|-----|-----|-----------------|
| 1 | Section 4.3 | `GET /beds/available` | `GET /rooms/beds/available` | `room.controller.ts` `@Controller('rooms')` + `@Get('beds/available')` |
| 2 | Section 3.2 response | `emergencyContact` + `emergencyPhone` + `"allergies": ["Penicillin"]` | 3 separate emergency contact fields + `detail.allergies: "Penicillin"` (string) | `PatientResponseDto` + `PatientDetailResponseDto` |
| 3 | Section 3.3 request | `patientNumber` + old emergency fields + `allergies` array | Removed auto-generated field; 3 emergency contact fields; no `allergies` (PatientDetail is separate) | `CreatePatientDto` |
| 4 | Section 7.2.1 (new) | — | `GET /rounds/by-number/:roundNumber` added | `rounding.controller.ts` `@Get('by-number/:roundNumber')` |
| 5 | README Roadmap | Phase 4 "Month 6" implying 6-month total | Phase 4 "Month 5" + explicit note "4–5 months" | `PRD.md` Section 9.3 schedule diagram |

### Testing Done
- [x] All endpoint paths verified against controller `@Get`/`@Post` decorators
- [x] All field names verified against DTO class properties
- [x] Prettier formatting applied by pre-commit hook

### Breaking Changes
None — documentation only.